### PR TITLE
docs: add DIVINESENSE_EVOLUTION_ENABLED config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,14 @@ DIVINESENSE_AI_DEEPSEEK_API_KEY=sk-your-deepseek-key
 # 启用 Geek Mode:
 DIVINESENSE_CLAUDE_CODE_ENABLED=false
 #
+# 启用 Evolution Mode (进化模式):
+#   进化模式是 Geek Mode 的高级形态，解锁完整的 Claude Code Agent 能力
+#   详见 EVOLUTION_MODE_SPEC.md
+DIVINESENSE_EVOLUTION_ENABLED=false
+#
+# Evolution Mode 仅限管理员 (可选):
+# DIVINESENSE_EVOLUTION_ADMIN_ONLY=true
+#
 # Docker 环境特殊说明:
 #   • Docker 容器内需要安装 Claude Code CLI
 #   • 建议在 Dockerfile 中添加:

--- a/deploy/aliyun/.env.prod.example
+++ b/deploy/aliyun/.env.prod.example
@@ -39,6 +39,16 @@ DIVINESENSE_AI_SILICONFLOW_API_KEY=sk-your-siliconflow-key
 DIVINESENSE_AI_DEEPSEEK_API_KEY=sk-your-deepseek-key
 
 # ==============================================================================
+# [可选] Evolution Mode - Claude Code Agent 进化模式
+# ==============================================================================
+#
+# 进化模式是 Geek Mode 的高级形态，解锁完整的 Claude Code Agent 能力
+# 前提条件: 需先启用 Geek Mode (DIVINESENSE_CLAUDE_CODE_ENABLED=true)
+#
+# DIVINESENSE_EVOLUTION_ENABLED=true
+# DIVINESENSE_EVOLUTION_ADMIN_ONLY=true  # 仅管理员可用 (可选)
+
+# ==============================================================================
 # [可选] AI 模型配置
 # ==============================================================================
 #

--- a/docker/compose/prod.yml
+++ b/docker/compose/prod.yml
@@ -80,6 +80,9 @@ services:
       - DIVINESENSE_AI_RERANK_MODEL=${DIVINESENSE_AI_RERANK_MODEL:-BAAI/bge-reranker-v2-m3}
       # Geek Mode: Claude Code CLI integration (optional)
       - DIVINESENSE_CLAUDE_CODE_ENABLED=${DIVINESENSE_CLAUDE_CODE_ENABLED:-false}
+      # Evolution Mode: Advanced Claude Code Agent (optional)
+      - DIVINESENSE_EVOLUTION_ENABLED=${DIVINESENSE_EVOLUTION_ENABLED:-false}
+      - DIVINESENSE_EVOLUTION_ADMIN_ONLY=${DIVINESENSE_EVOLUTION_ADMIN_ONLY:-true}
     ports:
       - "${DIVINESENSE_PORT:-5230}:5230"
     volumes:

--- a/docs/deployment/BINARY_DEPLOYMENT.md
+++ b/docs/deployment/BINARY_DEPLOYMENT.md
@@ -6,14 +6,14 @@
 
 ## 部署模式对比
 
-| 特性 | Docker 模式 | 二进制模式 |
-|:-----|:-----------|:---------|
-| Geek Mode 支持 | ⚠️ 需额外配置 | ✅ 原生支持 |
-| 资源占用 | 高 (容器开销) | 低 |
-| 启动速度 | 慢 | 快 |
-| 更新方式 | 重建镜像 | 替换二进制 |
-| 数据隔离 | 容器隔离 | 需手动配置 |
-| 适用场景 | 快速部署、测试 | Geek Mode、生产环境 |
+| 特性           | Docker 模式    | 二进制模式          |
+| :------------- | :------------- | :------------------ |
+| Geek Mode 支持 | ⚠️ 需额外配置   | ✅ 原生支持          |
+| 资源占用       | 高 (容器开销)  | 低                  |
+| 启动速度       | 慢             | 快                  |
+| 更新方式       | 重建镜像       | 替换二进制          |
+| 数据隔离       | 容器隔离       | 需手动配置          |
+| 适用场景       | 快速部署、测试 | Geek Mode、生产环境 |
 
 ---
 
@@ -124,6 +124,27 @@ npx @z_ai/coding-helper
 # 启用 Geek Mode
 DIVINESENSE_CLAUDE_CODE_ENABLED=true
 DIVINESENSE_CLAUDE_CODE_WORKDIR=/opt/divinesense/data
+```
+
+重启服务：
+
+```bash
+sudo systemctl restart divinesense
+```
+
+### 启用 Evolution Mode (进化模式)
+
+Evolution Mode 是 Geek Mode 的高级形态，解锁完整的 Claude Code Agent 能力。
+
+编辑 `/etc/divinesense/config`：
+
+```bash
+# 启用 Evolution Mode (需先启用 Geek Mode)
+DIVINESENSE_CLAUDE_CODE_ENABLED=true
+DIVINESENSE_EVOLUTION_ENABLED=true
+
+# 可选: 仅管理员可用
+DIVINESENSE_EVOLUTION_ADMIN_ONLY=true
 ```
 
 重启服务：


### PR DESCRIPTION
## Summary
添加 `DIVINESENSE_EVOLUTION_ENABLED` 环境变量配置到所有相关文件。

## 变更文件

| 文件 | 说明 |
|------|------|
| `.env.example` | 添加 Evolution Mode 配置说明和环境变量 |
| `deploy/aliyun/.env.prod.example` | 添加生产环境 Evolution Mode 配置块 |
| `docker/compose/prod.yml` | 传递 `EVOLUTION_ENABLED` 和 `EVOLUTION_ADMIN_ONLY` 环境变量 |
| `docs/deployment/BINARY_DEPLOYMENT.md` | 添加 Evolution Mode 启用说明 |

## Evolution Mode

进化模式是 Geek Mode 的高级形态，解锁完整的 Claude Code Agent 能力。

```bash
# 启用 Evolution Mode (需先启用 Geek Mode)
DIVINESENSE_CLAUDE_CODE_ENABLED=true
DIVINESENSE_EVOLUTION_ENABLED=true

# 可选: 仅管理员可用
DIVINESENSE_EVOLUTION_ADMIN_ONLY=true
```

详见 `docs/specs/EVOLUTION_MODE_SPEC.md`