### PR TITLE
fix(build): resolve Go embed compatibility with lodash-es

### DIFF
--- a/docs/dev-guides/FRONTEND.md
+++ b/docs/dev-guides/FRONTEND.md
@@ -97,6 +97,37 @@ DivineSense 使用 **pre-commit + pre-push** hooks 确保代码质量。
 
 **规则**：Grid 使用 `gap` 而非 `max-w-*`。如果 `max-width / column_count < 200px`，不要使用 `max-w-*`。
 
+### Go embed 兼容性
+
+**关键**：Go 的 `//go:embed` 会忽略以下划线 `_` 开头的文件。
+
+对于单二进制部署，前端构建产物必须避免生成以下划线开头的文件名。
+
+**问题示例**：
+```
+lodash-es 内部模块被拆分为：
+- _baseFlatten-xxx.js  ❌ 被 Go embed 忽略
+- _baseMap-xxx.js       ❌ 被 Go embed 忽略
+```
+
+**解决方案**：在 `vite.config.mts` 中配置 `manualChunks` 将 lodash-es 打包为单个 chunk：
+
+```typescript
+manualChunks(id) {
+  if (id.includes("lodash-es") || id.includes("/_base")) {
+    return "lodash-vendor";  // 生成 lodash-vendor-xxx.js
+  }
+  // ...
+}
+```
+
+**构建验证**：
+```bash
+ls web/dist/assets/ | grep "^_"  # 应该为空
+```
+
+详见：@docs/research/DEBUG_LESSONS.md → "Go embed 忽略以下划线开头的文件"
+
 ---
 
 ## 布局架构

--- a/server/router/frontend/service.go
+++ b/server/router/frontend/service.go
@@ -47,6 +47,10 @@ func (*FrontendService) Serve(_ context.Context, e *echo.Echo) {
 		// Security: Prevent MIME type sniffing
 		c.Response().Header().Set("X-Content-Type-Options", "nosniff")
 
+		// CORS support for ES modules loaded with crossorigin attribute
+		// Vite uses <link rel="modulepreload" crossorigin> which requires CORS headers
+		c.Response().Header().Set("Access-Control-Allow-Origin", "*")
+
 		ext := filepath.Ext(c.Path())
 		// For index.html, root path, and SPA routes (no extension),
 		// set no-cache headers to prevent browser caching.

--- a/web/vite.config.mts
+++ b/web/vite.config.mts
@@ -40,28 +40,43 @@ export default defineConfig({
     target: "es2020", // Modern browsers: Chrome 80+, Safari 13.1+, Firefox 72+
     rollupOptions: {
       output: {
-        manualChunks: {
+        // Sanitize chunk names to avoid leading underscores (Go embed ignores them)
+        chunkFileNames: "assets/[name]-[hash].js",
+        entryFileNames: "assets/[name]-[hash].js",
+        assetFileNames: "assets/[name]-[hash].[ext]",
+        manualChunks(id) {
+          // lodash-es internal modules - bundle into a single chunk
+          if (id.includes("lodash-es") || id.includes("/_base")) {
+            return "lodash-vendor";
+          }
           // Merge core-js dependent packages into main entry to avoid polyfill issues
-          "polyfills": ["core-js/actual"],
-          "react-vendor": ["react", "react-dom", "react-router-dom"],
-          "ui-vendor": [
-            "@radix-ui/react-dialog",
-            "@radix-ui/react-dropdown-menu",
-            "@radix-ui/react-popover",
-            "@radix-ui/react-select",
-            "@radix-ui/react-tooltip",
-            "@radix-ui/react-checkbox",
-            "@radix-ui/react-switch",
-            "lucide-react",
-          ],
-          "markdown-vendor": ["react-markdown", "remark-gfm", "remark-breaks", "rehype-raw", "rehype-sanitize", "highlight.js"],
-          "math-vendor": ["katex", "rehype-katex", "remark-math"],
-          "query-vendor": ["@tanstack/react-query"],
-          "i18n-vendor": ["i18next", "react-i18next"],
-          // graph-vendor and utils-vendor removed to avoid core-js polyfill issues
-          // These will be bundled with the main entry
-          "mermaid-vendor": ["mermaid"],
-          "leaflet-vendor": ["leaflet", "react-leaflet"],
+          if (id.includes("core-js/actual")) {
+            return "polyfills";
+          }
+          if (id.includes("react") || id.includes("react-dom") || id.includes("react-router")) {
+            return "react-vendor";
+          }
+          if (id.includes("@radix-ui") || id.includes("lucide-react")) {
+            return "ui-vendor";
+          }
+          if (id.includes("react-markdown") || id.includes("remark-") || id.includes("rehype-") || id.includes("highlight.js")) {
+            return "markdown-vendor";
+          }
+          if (id.includes("katex")) {
+            return "math-vendor";
+          }
+          if (id.includes("@tanstack/react-query")) {
+            return "query-vendor";
+          }
+          if (id.includes("i18next")) {
+            return "i18n-vendor";
+          }
+          if (id.includes("mermaid")) {
+            return "mermaid-vendor";
+          }
+          if (id.includes("leaflet")) {
+            return "leaflet-vendor";
+          }
         },
       },
     },


### PR DESCRIPTION
## 概述
修复生产环境部署后部分 JavaScript 文件无法加载导致应用崩溃的问题。

## 问题

部署到生产环境后，浏览器控制台报错：
```
Failed to fetch dynamically imported module: http://39.105.209.49/assets/Inboxes-3qwxzD_s.js
_baseFlatten-CWeGY8aD.js:1 Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "text/html"
```

## 根本原因

**Go embed 文件过滤规则**：`//go:embed` 会忽略**以下划线 `_` 开头的文件**（类似 Unix 的 `.` 隐藏文件）。

`lodash-es` 内部模块被 Vite/Rollup 拆分为独立 chunk：
- `_baseFlatten-xxx.js` ❌ 被 Go embed 忽略
- `_baseMap-xxx.js` ❌ 被 Go embed 忽略

## 变更内容

- [x] **vite.config.mts**: 使用函数式 `manualChunks` 将 lodash-es 打包为单个 chunk
- [x] **vite.config.mts**: 添加 `chunkFileNames/entryFileNames/assetFileNames` 规范文件名
- [x] **frontend/service.go**: 添加 CORS 头支持 ES 模块预加载
- [x] **DEBUG_LESSONS.md**: 记录调试经验教训
- [x] **FRONTEND.md**: 添加 Go embed 兼容性指南

## 关联 Issue
Resolves #31

## 测试计划
- [x] 本地测试通过
- [x] `make check-all` 通过
- [x] `ls web/dist/assets/ | grep "^_"` 为空
- [ ] 生产环境验证（待合并后部署）

## 截图/演示
无 UI 变更

## 检查清单
- [x] 代码遵循项目规范
- [x] 自我审查代码
- [x] 注释说明了复杂逻辑
- [x] 文档已更新
- [x] 无合并冲突

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>