### PR TITLE
feat(deploy): auto-configure user permissions and operation tools

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -291,6 +291,31 @@ EOF
 
     chown -R divine:divine "$INSTALL_DIR"
 
+    # ============================================================================
+    # 配置用户运维权限和工具
+    # ============================================================================
+    log_step "配置用户运维权限和工具..."
+
+    # 配置 docker 组（非关键）
+    if ! configure_docker_group; then
+        log_warn "Docker 组配置失败，继续安装..."
+    fi
+
+    # 配置 sudoers（关键）
+    if ! configure_sudoers; then
+        log_warn "sudoers 配置失败，用户可能需要输入密码来管理服务"
+    fi
+
+    # 创建 Makefile（非关键）
+    if ! create_user_makefile; then
+        log_warn "Makefile 创建失败"
+    fi
+
+    # 配置 bash 别名（非关键）
+    if ! configure_bash_aliases; then
+        log_warn "bash 别名配置失败"
+    fi
+
     log_success "安装完成"
 }
 

--- a/docs/deployment/BINARY_DEPLOYMENT.md
+++ b/docs/deployment/BINARY_DEPLOYMENT.md
@@ -73,20 +73,43 @@ cd /opt/divinesense
 3. 创建用户和目录
 4. 安装 systemd 服务
 5. 配置 PostgreSQL (Docker 或系统)
-6. 启动服务
+6. **配置用户运维权限**（自动完成）：
+   - divine 用户加入 docker 组
+   - 配置 sudoers 免密（仅限服务管理命令）
+   - 创建 `~/Makefile` 运维工具
+   - 配置 bash 快捷别名
+7. 启动服务
 
 ### 服务管理
 
+**方式一：用户 Makefile（推荐，无需 sudo 密码）**
+
+安装完成后，divine 用户主目录会自动创建运维 Makefile：
+
 ```bash
-/opt/divinesense/deploy-binary.sh status     # 查看状态
-/opt/divinesense/deploy-binary.sh logs       # 查看日志
-/opt/divinesense/deploy-binary.sh restart    # 重启服务
-/opt/divinesense/deploy-binary.sh backup     # 备份数据
-/opt/divinesense/deploy-binary.sh restore    # 恢复数据
-/opt/divinesense/deploy-binary.sh upgrade    # 升级版本
+# SSH 登录后使用（以 divine 用户）
+make help          # 查看所有命令
+make status        # 查看服务状态
+make health        # 健康检查
+make restart       # 重启服务
+make logs          # 查看日志
+make db-backup     # 备份数据库
+make db-shell      # 进入数据库 Shell
+make upgrade       # 升级到最新版本
+make clone-source  # 克隆源码（Evolution Mode）
 ```
 
-### systemd 命令
+**快捷别名**（重新登录生效）：
+
+```bash
+ds-status    # 等同于 make status
+ds-restart   # 等同于 make restart
+ds-health    # 等同于 make health
+ds-backup    # 等同于 make db-backup
+ds-db        # 等同于 make db-shell
+```
+
+**方式二：systemd 命令**
 
 ```bash
 sudo systemctl status divinesense    # 查看状态


### PR DESCRIPTION
## 概述
改进二进制部署模式，自动配置 divine 用户的运维权限和工具，解决部署后用户无法方便管理服务的问题。

## 变更内容
### 新增功能
- **用户权限自动配置**：
  - divine 用户自动加入 docker 组
  - sudoers 免密配置（仅限 DivineSense 服务管理命令）
  - visudo -c 语法验证，失败自动回滚

- **用户运维工具**：
  - `~/Makefile` - 服务/数据库/版本/源码管理命令
  - `ds-*` 快捷别名（ds-status, ds-restart, ds-health 等）

### 文件变更
| 文件 | 变更 |
|:-----|:-----|
| `deploy/lib/common.sh` | +363 行（新增 6 个权限配置函数） |
| `deploy/install.sh` | 调用权限配置，添加返回值检查 |
| `docs/deployment/BINARY_DEPLOYMENT.md` | 更新服务管理说明 |
| `docs/research/DEBUG_LESSONS.md` | 记录运维权限问题 |

## 使用示例
安装后用户可直接使用：
```bash
make status    # 查看服务状态（无需密码）
make restart   # 重启服务
make health    # 健康检查
make db-backup # 备份数据库
make upgrade   # 升级到最新版本
```

快捷别名：
```bash
ds-status    # 等同于 make status
ds-restart   # 等同于 make restart
ds-health    # 等同于 make health
```

## 安全性
- ✅ sudoers 仅开放必要命令（systemctl status/start/stop/restart divinesense.service）
- ✅ visudo -c 语法验证，失败自动回滚
- ✅ 无 eval 使用，所有命令使用安全变量展开
- ✅ 用户存在性验证，家目录动态获取

## 关联 Issue
Resolves #35

## 检查清单
- [x] 代码审查通过
- [x] 所有函数有返回值检查
- [x] sudoers 配置包含 visudo -c 验证
- [x] 语法检查通过
- [x] Pre-push 检查通过（golangci-lint + pnpm lint + test）

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>