### PR TITLE
fix(dev): resolve build error for make start without frontend dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,13 +94,13 @@ dev: run ## Alias for run
 web: ## 启动前端开发服务器
 	@cd $(WEB_DIR) && pnpm dev
 
-start: build ## 一键启动所有服务 (自动构建最新版本)
+start: ## 一键启动所有服务 (使用 go run 开发模式)
 	@$(SCRIPT_DIR)/dev.sh start
 
 stop: ## 一键停止所有服务
 	@$(SCRIPT_DIR)/dev.sh stop
 
-restart: build ## 重启所有服务 (自动构建最新版本)
+restart: ## 重启所有服务 (使用 go run 开发模式)
 	@$(SCRIPT_DIR)/dev.sh restart
 
 status: ## 查看所有服务状态

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -194,7 +194,7 @@ start_backend() {
     load_env
 
     # 启动后端（后台运行）
-    nohup go run ./cmd/divinesense --mode dev --port $BACKEND_PORT \
+    nohup go run -tags=noui ./cmd/divinesense --mode dev --port $BACKEND_PORT \
         > "$BACKEND_LOG" 2>&1 &
 
     local pid=$!


### PR DESCRIPTION
## 概述
修复 `make start` 命令因缺少前端 dist 目录而报错的问题。

## 变更内容
- [x] 移除 `start` 和 `restart` 对 `build` 目标的依赖
- [x] 在 `scripts/dev.sh` 中添加 `-tags=noui` 标志
- [x] 更新注释说明使用 go run 开发模式

## 关联 Issue
Resolves #42

## 根本原因
1. `make start` 依赖 `build` 目标，而 `build` 需要嵌入前端静态资源
2. `frontend_prod.go` 使用 `//go:embed dist/*` 但 `server/router/frontend/dist` 目录不存在
3. Go embed 不支持 symlink，无法通过软链接解决

## 解决方案
- 开发环境使用 `-tags=noui` 标志，使用 `frontend.go` 而非 `frontend_prod.go`
- 生产构建仍会使用 `make build-all` 完整构建前后端

## 测试计划
- [x] 本地测试 `make start` 通过
- [x] 所有服务正常启动（PostgreSQL + 后端 + 前端）
- [x] 后端日志无 embed 相关错误
- [x] `make stop` 和 `make restart` 正常工作

## 截图/演示
```
✅ PostgreSQL: 运行中
✅ 后端:       运行中 (PID: 36306, http://localhost:28081)
✅ 前端:       运行中 (PID: 36675, http://localhost:25173)
```

## 检查清单
- [x] 代码遵循项目规范
- [x] 自我审查代码
- [x] 注释说明了复杂逻辑
- [x] 文档已同步更新（Makefile 注释）
- [x] 无合并冲突

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>