### PR TITLE
refactor(version): implement unified version management system

### DIFF
--- a/cmd/divinesense/main.go
+++ b/cmd/divinesense/main.go
@@ -106,6 +106,20 @@ func init() {
 	viper.SetDefault("driver", "postgres")
 	viper.SetDefault("port", 28081)
 
+	// Set version for cobra - use short version for the flag
+	rootCmd.Version = version.Version
+
+	// Add version subcommand for detailed version info
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Display detailed version information",
+		Run: func(_ *cobra.Command, _ []string) {
+			fmt.Printf("DivineSense %s\n", version.String())
+			fmt.Println(version.StringFull())
+		},
+	}
+	rootCmd.AddCommand(versionCmd)
+
 	rootCmd.PersistentFlags().String("mode", "dev", `mode of server, can be "prod" or "dev" or "demo"`)
 	rootCmd.PersistentFlags().String("addr", "", "address of server")
 	rootCmd.PersistentFlags().Int("port", 28081, "port of server")

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,11 +8,27 @@ import (
 )
 
 // Version is the service current released version.
+// This value can be overridden at build time using ldflags:
+//
+//	go build -ldflags "-X github.com/hrygo/divinesense/internal/version.Version=v0.95.0"
+//
 // Semantic versioning: https://semver.org/
-var Version = "0.93.0"
+var Version = "0.0.0-dev"
 
 // DevVersion is the service current development version.
-var DevVersion = "0.93.0"
+var DevVersion = Version
+
+// GitCommit is the git commit hash at build time.
+// Set via ldflags: -X github.com/hrygo/divinesense/internal/version.GitCommit=$(git rev-parse HEAD)
+var GitCommit = "unknown"
+
+// GitBranch is the git branch at build time.
+// Set via ldflags: -X github.com/hrygo/divinesense/internal/version.GitBranch=$(git rev-parse --abbrev-ref HEAD)
+var GitBranch = "unknown"
+
+// BuildTime is the build timestamp in RFC3339 format.
+// Set via ldflags: -X github.com/hrygo/divinesense/internal/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+var BuildTime = "unknown"
 
 func GetCurrentVersion(mode string) string {
 	if mode == "dev" || mode == "demo" {
@@ -57,4 +73,37 @@ func (s SortVersion) Less(i, j int) bool {
 	v1 := fmt.Sprintf("v%s", s[i])
 	v2 := fmt.Sprintf("v%s", s[j])
 	return semver.Compare(v1, v2) == -1
+}
+
+// String returns the version string with optional commit hash.
+func String() string {
+	v := Version
+	if GitCommit != "" && GitCommit != "unknown" {
+		shortCommit := GitCommit
+		if len(shortCommit) > 8 {
+			shortCommit = shortCommit[:8]
+		}
+		v = fmt.Sprintf("%s-%s", v, shortCommit)
+	}
+	return v
+}
+
+// StringFull returns the complete version information including build metadata.
+func StringFull() string {
+	var parts []string
+	parts = append(parts, fmt.Sprintf("Version=%s", Version))
+	if GitCommit != "" && GitCommit != "unknown" {
+		shortCommit := GitCommit
+		if len(shortCommit) > 8 {
+			shortCommit = shortCommit[:8]
+		}
+		parts = append(parts, fmt.Sprintf("Commit=%s", shortCommit))
+	}
+	if GitBranch != "" && GitBranch != "unknown" {
+		parts = append(parts, fmt.Sprintf("Branch=%s", GitBranch))
+	}
+	if BuildTime != "" && BuildTime != "unknown" {
+		parts = append(parts, fmt.Sprintf("BuildTime=%s", BuildTime))
+	}
+	return strings.Join(parts, " ")
 }


### PR DESCRIPTION
## 概述
统一项目版本管理，以 Git tag 作为单一数据源，通过构建时注入版本信息。

Resolves #107

## 变更内容

### 版本管理架构
```
Git Tag (单一数据源)
    │
    ├─── Makefile LDFLAGS ────► Go 二进制
    │                              │
    └─── API (profile.version) ───► 前端显示
```

### 文件变更

**internal/version/version.go**
- 添加 `GitCommit`、`GitBranch`、`BuildTime` 变量
- 添加 `String()` 和 `StringFull()` 格式化函数
- 默认版本改为 `0.0.0-dev`（构建时覆盖）

**Makefile**
- 添加版本变量定义（从 Git 获取）
- 添加 `LDFLAGS` 用于构建时注入
- 新增命令：
  - `make version` - 显示构建时版本
  - `make version-json` - JSON 格式输出
  - `make version-verbose` - 运行时版本

**cmd/divinesense/main.go**
- 添加 `version` 子命令
- `--version` 标志显示简洁版本

**CI 修复**
- `ci-backend` 现在正确排除 `plugin/cron` 包

## 测试计划
- [x] 本地测试 `make version` 输出正确
- [x] 本地测试 `make build` 成功构建
- [x] 本地测试 `./bin/divinesense version` 输出正确
- [x] `make ci-backend` 通过

## 截图/演示

```bash
$ make version
DivineSense Version Information
==============================
Version:    0.95.0-12-ge7c57782-dirty
Commit:     e7c57782cc327a45a6e0ceeffb3219ec7f17d34a
Branch:     feat/unified-version-management
Build Time: 2026-02-07T04:52:42Z

$ ./bin/divinesense version
DivineSense 0.95.0-12-ge7c57782-dirty-e7c57782
Version=0.95.0-12-ge7c57782-dirty Commit=e7c57782 Branch=feat/unified-version-management BuildTime=2026-02-07T04:55:32Z
```

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>