### PR TITLE
feat(ci): add divinesense-code-reviewer v5.0.0 agent

### DIFF
--- a/.claude/agent-memory/divinesense-code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/divinesense-code-reviewer/MEMORY.md
@@ -1,0 +1,98 @@
+# DivineSense Code Reviewer - Agent Memory
+
+> **Version**: 5.0.0
+> **Purpose**: 持久化项目特定知识，提升审查精准度
+
+---
+
+## 快速索引
+
+| 主题 | 位置 | 描述 |
+|:-----|:-----|:-----|
+| Go 惯用模式 | `patterns/go_patterns.md` | Go 代码惯用写法 |
+| React 模式 | `patterns/react_patterns.md` | React 组件模式 |
+| 反模式/陷阱 | `patterns/anti_patterns.md` | 常见错误和陷阱 |
+| 路由决策 | `decisions/routing.md` | AI 路由架构决策 |
+| 数据库决策 | `decisions/database.md` | 数据库相关决策 |
+| 安全事件 | `incidents/security.md` | 历史安全问题 |
+| 性能问题 | `incidents/performance.md` | 历史性能问题 |
+
+---
+
+## 项目架构速记
+
+### 核心原则
+- **减法 > 加法**：优先删除重复代码，而非添加抽象
+- **显式 > 隐式**：明确表达意图，避免魔法
+- **DRY > 抽象**：先消除重复，再考虑抽象
+
+### 目录结构关键点
+```
+ai/              # AI 一级模块（非 server/ai/ 或 plugin/ai/）
+├── agent/       # 五位鹦鹉代理
+├── router/      # 三层意图路由
+├── core/        # AI 基础设施（embedding, retrieval, reranker, llm）
+└── ...
+
+server/          # HTTP/gRPC 服务器
+├── router/      # API 处理器
+├── service/     # 业务逻辑
+└── ...
+
+plugin/          # 非AI 插件（调度器、存储、Markdown、OCR等）
+store/           # 数据访问层接口
+```
+
+### AI 路由优先级
+```
+EvolutionMode (最高) → GeekMode → AUTO → 四层路由
+                                            ↓
+                    Cache (0ms) → Rule (0ms) → History (~10ms) → LLM (~400ms)
+```
+
+### 常见陷阱
+- ❌ Tailwind CSS 4: `max-w-sm/md/lg/xl` 会坍缩到 ~16px
+- ✅ 使用显式值：`max-w-[24rem]`, `max-w-[28rem]`
+- ❌ Go embed 忽略 `_` 前缀文件
+- ✅ Vite 配置 `manualChunks` 避免 lodash 拆分
+
+### 数据库迁移同步
+**Critical**: 每次变更必须同时更新：
+1. `store/migration/postgres/migrate/YYYYMMDDHHMMSS_*.up.sql`
+2. `store/migration/postgres/schema/LATEST.sql`
+
+---
+
+## 审查统计
+
+| 指标 | 值 |
+|:-----|:---|
+| Agent 版本 | 5.0.0 |
+| 记忆文件数 | 5 |
+| 专项审查器 | 7 |
+
+---
+
+## 能力概览
+
+### 7 个专业子代理
+- **architecture**: 架构完整性、模块边界、路由一致性
+- **go-quality**: Go 代码质量、命名规范、错误处理
+- **react**: React/TypeScript、Tailwind 陷阱、i18n
+- **database**: 数据库迁移、事务安全、pgvector
+- **security**: 安全漏洞、性能问题、N+1 查询
+- **testing**: 测试覆盖、godoc 注释、文档同步
+- **prophet**: 预测分析、风险分布、影响评估
+
+### 信心度评分标准
+- **100**: 绝对确定（编译错误、安全漏洞）
+- **90-99**: 高度确认（架构违规、明显 bug）
+- **80-89**: 建议修复（代码质量、性能问题）
+- **<80**: 过滤不报（nitpick、风格偏好、不确定问题）
+
+### 支持的审查模式
+- **PR Review**: "Review PR #123"
+- **Incremental**: "Review changes", "Check staged"
+- **Focused**: "Review ai/agent/file.go"
+- **Pre-Commit**: "Before commit", "Pre-push check"
+- **Full**: "Review all"

--- a/.claude/agent-memory/divinesense-code-reviewer/decisions/database.md
+++ b/.claude/agent-memory/divinesense-code-reviewer/decisions/database.md
@@ -1,0 +1,144 @@
+# 架构决策记录
+
+> DivineSense 项目的关键架构决策及其理由
+
+---
+
+## AI 模块组织
+
+### 决策：AI 作为一级模块
+
+```
+ai/               # ✅ 一级模块
+├── agent/        # 鹦鹉代理
+├── router/       # 意图路由
+├── core/         # AI 基础设施
+└── ...
+
+server/ai/        # ❌ 不使用
+plugin/ai/        # ❌ 不使用（插件为非AI）
+```
+
+**理由**：
+- AI 是核心功能，不是附加组件
+- 简化导入路径：`ai/agent/` vs `server/router/api/v1/ai/agent/`
+- 清晰的架构边界：AI 模块独立演进
+
+**相关**：
+- `plugin/` 目录包含非 AI 插件（Markdown、OCR、Webhook等）
+- `server/` 专注于 HTTP/gRPC 服务层
+
+---
+
+## 数据库策略
+
+### 决策：PostgreSQL 生产级，SQLite 仅开发
+
+| 环境 | 数据库 | AI 支持 |
+|:-----|:-------|:-------|
+| 生产 | PostgreSQL | ✅ 完整支持 |
+| 开发 | PostgreSQL | ✅ 完整支持 |
+| 开发（可选）| SQLite | ❌ 无 AI |
+
+**理由**：
+- `pgvector` 扩展是向量搜索的基础
+- SQLite 不支持 pgvector，限制 AI 功能
+- 开发环境可用 SQLite 进行非 AI 功能开发
+
+**相关 Issue**: #9 - SQLite AI 支持研究
+
+---
+
+## 路由机制
+
+### 决策：四层意图路由 + AUTO 标记
+
+```
+用户输入 → EvolutionMode? ─Yes→ EvolutionParrot
+                  │
+                  No
+                  ↓
+           GeekMode? ─Yes→ GeekParrot
+                  │
+                  No
+                  ↓
+           AgentType == AUTO?
+                  │
+           Yes ─────┴── No (直接使用指定鹦鹉)
+                  ↓
+           ChatRouter.Route()
+                  ↓
+    Cache → Rule → History → LLM
+```
+
+**关键理解**：
+- `AUTO` 不是一只鹦鹉，是"请后端路由"的标记
+- 五只鹦鹉：MEMO, SCHEDULE, AMAZING, GEEK, EVOLUTION
+- 路由层有优先级：Evolution > Geek > 具体鹦鹉 > AUTO
+
+---
+
+## 数据库迁移
+
+### 决策：双文件同步
+
+每次数据库变更必须同步更新：
+1. `store/migration/postgres/migrate/YYYYMMDDHHMMSS_description.up.sql`
+2. `store/migration/postgres/schema/LATEST.sql`
+
+**理由**：
+- `migrate/` 支持增量升级（已部署数据库）
+- `LATEST.sql` 支持全新安装
+- 不一致会导致：新安装缺少表 / 升级后结构不同
+
+**验证命令**：
+```bash
+# 检查表数量一致性
+grep -c '^CREATE TABLE' migrate/*.up.sql
+grep -c '^CREATE TABLE' schema/LATEST.sql
+```
+
+---
+
+## Unified Block Model
+
+### 决策：AI 聊天使用统一块模型
+
+```
+AIBlock {
+    id, uid, conversation_id, round_number
+    mode: normal | geek | evolution
+    user_inputs[]
+    assistant_content
+    event_stream[]
+    session_stats
+    status: pending | streaming | completed | error
+}
+```
+
+**理由**：
+- 统一的数据结构支持多种模式
+- 流式事件持久化（thinking, tool_use, answer）
+- 会话统计（tokens, cost）可追溯
+
+**相关**：
+- 前端：`UnifiedMessageBlock` 组件
+- 数据库表：`ai_block`
+
+---
+
+## 前端状态管理
+
+### 决策：TanStack Query 为主，Context API 辅助
+
+| 用途 | 方案 |
+|:-----|:-----|
+| 服务器状态 | TanStack Query |
+| 全局 UI 状态 | Context API |
+| 组件本地状态 | useState |
+| 表单状态 | useState + useImmer |
+
+**理由**：
+- TanStack Query 自动处理缓存、重试、失效
+- Context API 适合全局 UI（主题、语言、用户）
+- 避免过度抽象，保持简单

--- a/.claude/agent-memory/divinesense-code-reviewer/incidents/security.md
+++ b/.claude/agent-memory/divinesense-code-reviewer/incidents/security.md
@@ -1,0 +1,67 @@
+# 安全事件记录
+
+> DivineSense 历史安全问题及修复记录
+
+---
+
+## 开发模式固定密钥
+
+### 问题
+```go
+// server/server.go:60-63
+if profile.Mode == "dev" {
+    secret = "divinesense"  // 固定密钥！
+}
+```
+
+### 影响
+- 生产环境误用开发模式会导致会话可被预测
+- 所有 JWT 签名可被伪造
+- 用户认证完全失效
+
+### 修复建议
+```go
+// 即使开发模式也应使用随机密钥
+secret = generateRandomKey()
+// 或通过环境变量显式设置
+secret = os.Getenv("DIVINESENSE_SECRET_KEY")
+```
+
+### 相关文件
+- `server/server.go:60-63`
+
+---
+
+## 历史问题
+
+### Go Embed 文件忽略
+
+**问题**：Vite 打包生成 `_lodash-internal.js` 被 Go embed 忽略
+
+**修复**：配置 `manualChunks` 将 lodash 打包为单个 chunk
+
+**相关**：
+- `vite.config.mts`
+- `docs/research/DEBUG_LESSONS.md`
+
+---
+
+### 密钥比较时序攻击
+
+**问题**：`len(key) != 32` 使用 `!=` 比较可能被时序攻击
+
+**修复**：使用 `crypto/subtle.ConstantTimeCompare`
+
+**相关文件**：
+- `plugin/chat_apps/store/crypto.go:22`
+
+---
+
+### DSN 密码打印
+
+**问题**：开发模式下 DSN 可能包含密码但直接打印
+
+**修复**：打印前移除密码部分
+
+**相关文件**：
+- `cmd/divinesense/main.go:182-186`

--- a/.claude/agent-memory/divinesense-code-reviewer/patterns/anti_patterns.md
+++ b/.claude/agent-memory/divinesense-code-reviewer/patterns/anti_patterns.md
@@ -1,0 +1,186 @@
+# React/TypeScript 反模式与陷阱
+
+> DivineSense 前端开发中的常见错误和陷阱
+
+---
+
+## 🔴 Critical: Tailwind CSS 4 陷阱
+
+### 问题：语义化类名解析错误
+
+Tailwind CSS 4 重新定义了容器宽度类，导致意外的布局问题：
+
+```tsx
+// ❌ 错误：这些类解析为 ~16px（而非期望的容器宽度）
+<DialogContent className="max-w-md">      // 期望 384px，实际 ~16px
+<SheetContent className="sm:max-w-sm">   // 期望 320px，实际 ~16px
+<Sheet className="max-w-lg">            // 期望 512px，实际 ~16px
+```
+
+**原因**：Tailwind v4 使用 `--spacing-*` 变量，约 16px（而非传统容器宽度）
+
+```tsx
+// ✅ 正确：使用显式 rem 值
+<DialogContent className="max-w-[28rem]">  // 448px
+<SheetContent className="sm:max-w-[24rem]"> // 384px
+<Sheet className="max-w-[32rem]">          // 512px
+```
+
+**常用宽度参考**：
+| 用途 | rem 值 | 像素 |
+|:-----|:-------|:-----|
+| 小对话框 | `max-w-[24rem]` | 384px |
+| 标准对话框 | `max-w-[28rem]` | 448px |
+| 大对话框 | `max-w-[32rem]` | 512px |
+| 宽内容 | `max-w-[42rem]` | 672px |
+
+---
+
+## 🔴 Critical: Flex 容器溢出
+
+### 问题：h-full + padding 导致高度溢出
+
+```tsx
+// ❌ 错误：内层高度 = 100% + padding，导致溢出
+<div className="flex-1 overflow-y-auto px-3 py-4">
+  <div className="h-full w-full px-6 py-8">
+    {/* 内容 */}
+  </div>
+</div>
+```
+
+**原因**：`h-full` = 100%，加上 `py-8` (64px) 超出父容器
+
+```tsx
+// ✅ 正确：使用 min-h-0 允许收缩
+<div className="flex-1 overflow-y-auto px-3 py-4">
+  <div className="min-h-0 w-full px-6 py-8">
+    {/* 内容 */}
+  </div>
+</div>
+```
+
+---
+
+## 🟡 常见错误
+
+### Grid 容器上使用 max-w-*
+
+```tsx
+// ❌ 错误：导致列宽挤压
+<div className="grid grid-cols-2 gap-3 max-w-xs">
+  <Card /> <Card />  {/* 每列 160px - 被挤压 */}
+</div>
+
+// ✅ 正确：让 gap 控制宽度
+<div className="grid grid-cols-2 gap-3">
+  <Card /> <Card />
+</div>
+```
+
+### i18n 硬编码
+
+```tsx
+// ❌ 错误：硬编码文本
+<Button>Submit</Button>
+<div className="text-red-500">Error occurred</div>
+
+// ✅ 正确：使用 t() 函数
+<Button>{t("button.submit")}</Button>
+<div className="text-red-500">{t("errors.network")}</div>
+```
+
+### 组件命名
+
+```tsx
+// ❌ 错误：非 PascalCase
+const userProfile = () => { ... }
+const User_Profile = () => { ... }
+
+// ✅ 正确：PascalCase
+const UserProfile = () => { ... }
+```
+
+### Hooks 命名
+
+```tsx
+// ❌ 错误：缺少 use 前缀
+const getData = () => { ... }
+const UserState = () => { ... }
+
+// ✅ 正确：use 前缀
+const useGetData = () => { ... }
+const useUserState = () => { ... }
+```
+
+---
+
+## 性能陷阱
+
+### 未使用 React.memo 的列表项
+
+```tsx
+// ❌ 错误：每次父组件更新都重新渲染
+{items.map(item => (
+  <MemoCard key={item.id} memo={item} />
+))}
+
+// ✅ 正确：用 memo 包装
+const MemoCard = memo(({ memo }) => {
+  // ...
+}, (prev, next) => prev.memo.id === next.memo.id);
+```
+
+### 未使用 useCallback 的事件处理
+
+```tsx
+// ❌ 错误：每次渲染创建新函数
+<MemoCard onClick={() => handleClick(item.id)} />
+
+// ✅ 正确：使用 useCallback
+const handleClickItem = useCallback((id: string) => {
+  handleClick(id);
+}, [handleClick]);
+
+<MemoCard onClick={handleClickItem} />
+```
+
+---
+
+## TanStack Query 模式
+
+```tsx
+// ✅ 正确的数据获取模式
+const { data, isLoading, error } = useQuery({
+  queryKey: ["blocks", conversationId],
+  queryFn: () => api.blocks.list(conversationId),
+  staleTime: 5 * 60 * 1000,  // 5分钟
+});
+
+// ✅ 正确的变更模式
+const mutation = useMutation({
+  mutationFn: (block: BlockCreate) => api.blocks.create(block),
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ["blocks"] });
+  },
+});
+```
+
+---
+
+## 文件结构陷阱
+
+### 组件与 hooks 分离
+
+```
+// ✅ 正确结构
+components/AIChat/
+├── ChatMessages.tsx       # 组件
+├── useChatMessages.ts     # 组件专用 hook
+├── ChatMessages.test.tsx  # 测试
+└── types.ts               # 类型定义
+
+// ❌ 避免：组件逻辑全部塞在一个文件
+components/AIChat/
+├── ChatMessages.tsx       # 2000+ 行，包含 hooks、类型、逻辑
+```

--- a/.claude/agent-memory/divinesense-code-reviewer/patterns/go_patterns.md
+++ b/.claude/agent-memory/divinesense-code-reviewer/patterns/go_patterns.md
@@ -1,0 +1,176 @@
+# Go 惯用模式
+
+> DivineSense Go 代码的惯用写法和良好实践
+
+---
+
+## 命名规范
+
+### 文件命名
+```go
+// ✅ 正确：snake_case.go
+session_manager.go
+intent_classifier.go
+block_manager.go
+
+// ❌ 错误：kebab-case 或 PascalCase
+session-manager.go
+IntentClassifier.go
+```
+
+### 包命名
+```go
+// ✅ 简单小写单词
+package agent
+package router
+package context
+
+// ❌ 下划线或混合大小写
+package ai_agent
+package aiRouter
+```
+
+---
+
+## 错误处理
+
+### 标准错误检查
+```go
+// ✅ 始终检查错误
+rows, err := db.Query(ctx, query)
+if err != nil {
+    return fmt.Errorf("failed to query: %w", err)
+}
+defer rows.Close()
+
+// ❌ 忽略错误
+rows, err := db.Query(ctx, query)
+// 继续使用 rows 而不检查 err
+```
+
+### 错误包装
+```go
+// ✅ 使用 %w 保留错误链
+return fmt.Errorf("failed to create block: %w", err)
+
+// ❌ 使用 %v 断开错误链
+return fmt.Errorf("failed to create block: %v", err)
+```
+
+### 事务回滚
+```go
+// ✅ 正确处理嵌套事务
+if err := fn(tx); err != nil {
+    if isNewTx {
+        if rbErr := tx.Rollback(); rbErr != nil {
+            return fmt.Errorf("original: %w (rollback: %v)", err, rbErr)
+        }
+    }
+    return err
+}
+```
+
+---
+
+## 日志规范
+
+### 结构化日志
+```go
+// ✅ 使用 log/slog 结构化日志
+slog.Info("AI chat started",
+    "agent_type", req.AgentType,
+    "user_id", req.UserID,
+    "mode", req.Mode,
+)
+
+// ❌ 使用 fmt.Printf 或 log.Printf
+fmt.Printf("AI chat started: %+v\n", req)
+```
+
+### 日志级别
+```go
+slog.Debug("详细调试信息")     // 开发环境
+slog.Info("常规业务操作")       // 重要事件
+slog.Warn("可恢复的异常")       // 需要注意但不影响运行
+slog.Error("需要关注的错误")    // 错误已处理但需要跟踪
+```
+
+---
+
+## Context 使用
+
+```go
+// ✅ 传递带超时的 context
+ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+defer cancel()
+
+// ❌ 使用 Background()（除非确实必要）
+ctx := context.Background()
+```
+
+---
+
+## Go Embed 兼容
+
+```go
+// ❌ 以下划线开头的文件会被 embed 忽略
+_lodash_internal.js
+_utils.go
+
+// ✅ 修改配置避免生成以下划线开头的文件
+// vite.config.mts
+manualChunks(id) {
+    if (id.includes("lodash-es") || id.includes("/_base")) {
+        return "lodash-vendor";  // 生成 lodash-vendor-xxx.js
+    }
+}
+```
+
+---
+
+## 数据库操作
+
+```go
+// ✅ 使用参数化查询
+rows, err := db.Query(ctx, "SELECT * FROM user WHERE id = $1", userID)
+
+// ❌ 字符串拼接（SQL 注入风险）
+query := fmt.Sprintf("SELECT * FROM user WHERE id = %s", userID)
+```
+
+---
+
+## 常见模式
+
+### 接口模式
+```go
+// store/ 接口定义
+type BlockStore interface {
+    CreateBlock(ctx context.Context, block *AIBlock) (*AIBlock, error)
+    GetBlock(ctx context.Context, id int64) (*AIBlock, error)
+}
+
+// 具体实现
+type postgresBlockStore struct {
+    db *sql.DB
+}
+```
+
+### 工厂模式
+```go
+// ai/agent/ 工厂函数
+func NewParrotAgent(
+    agentType ParrotAgentType,
+    config *AgentConfig,
+    deps *AgentDeps,
+) (ParrotAgent, error) {
+    switch agentType {
+    case ParrotAgentType.MEMO:
+        return NewMemoParrot(config, deps), nil
+    case ParrotAgentType.GEEK:
+        return NewGeekParrot(config, deps), nil
+    default:
+        return nil, fmt.Errorf("unknown agent type: %s", agentType)
+    }
+}
+```

--- a/.claude/agent-memory/divinesense-code-reviewer/session_manager_review.md
+++ b/.claude/agent-memory/divinesense-code-reviewer/session_manager_review.md
@@ -1,0 +1,65 @@
+# session_manager.go 审查记录
+
+> **审查结果**: 🟡 良好 (3个中等问题，2个建议)
+> **Agent Version**: 5.0.0
+
+## 关键发现
+
+### 架构合规性 ✅
+- 文件位置正确: `ai/agent/session_manager.go`
+- 符合 DivineSense AI 模块一级目录规范
+- 依赖方向正确 (无非法上层依赖)
+
+### 代码质量 🟡
+**优点**:
+- 双重 `sync.RWMutex` 并发控制优秀
+- 错误路径资源清理完整
+- 结构化日志 (`log/slog`) 使用规范
+- 符合 Go 命名规范
+
+**缺点**:
+- 缺少单元测试 (`session_manager_test.go` 不存在)
+- 30分钟超时未定义为常量
+
+### 测试覆盖 🔴
+- SessionManager: 0% 覆盖
+- Session 方法: 0% 覆盖
+- CCRunnerConfig: 已覆盖 (`cc_test.go`)
+
+## 常见模式
+
+### 并发安全模式
+```go
+// 双重锁保护
+sm.mu.Lock()         // Manager 级别锁
+s.mu.Lock()          // Session 级别锁
+// 操作...
+s.mu.Unlock()
+sm.mu.Unlock()
+```
+
+### Timer 清理模式
+```go
+if s.statusResetTimer != nil {
+    if !s.statusResetTimer.Stop() {
+        // Timer 可能已触发，短暂等待回调完成
+        s.mu.Unlock()
+        time.Sleep(50 * time.Millisecond)
+        s.mu.Lock()
+    }
+}
+```
+
+## 改进建议优先级
+
+1. **高**: 创建 `session_manager_test.go`
+2. **中**: 添加 `DefaultSessionTimeout` 常量
+3. **低**: 统一注释语言
+4. **低**: `waitForReady` 超时日志
+
+## 关联文件
+
+- `ai/agent/cc_mode.go` - CCRunnerConfig 定义
+- `ai/agent/types.go` - 通用类型定义
+- `ai/agent/cc_test.go` - 测试模式参考
+- `docs/specs/cc_runner_async_arch.md` - 架构规格

--- a/.claude/agents/divinesense-code-reviewer.md
+++ b/.claude/agents/divinesense-code-reviewer.md
@@ -1,0 +1,143 @@
+---
+name: divinesense-code-reviewer
+version: 5.0.0
+description: "DivineSense 代码审查专家 — 多子代理并行架构 + 信心度过滤。**Use proactively** after code changes, before commits, when reviewing PRs, or when quality issues are suspected. Supports PR review, incremental changes, focused file review, and pre-commit checks."
+allowed-tools: Read, Grep, Glob, Bash, Task, TaskCreate, TaskUpdate, TaskList
+parameters:
+  type: object
+  properties:
+    mode:
+      type: string
+      enum: [pr, incremental, focused, pre-commit, full, auto]
+      default: auto
+    target:
+      type: string
+      description: "审查目标（PR号、文件路径、模块等）"
+    confidence:
+      type: integer
+      default: 80
+      minimum: 0
+      maximum: 100
+      description: "信心度阈值（0-100），仅报告≥阈值的问题"
+    parallel:
+      type: boolean
+      default: true
+    agents:
+      type: array
+      items:
+        type: string
+      enum: [architecture, go-quality, react, database, security, testing, prophet]
+      default: [architecture, go-quality, react, database, security, testing, prophet]
+      description: "启用的子代理"
+parallel: true
+run_in_background: false
+system: |
+  你是 DivineSense 代码审查 Agent 的**主协调器**。
+
+  **核心职责**：
+  1. 解析用户输入，检测审查模式
+  2. 将审查任务分发给专业子代理
+  3. 并行执行子代理，收集结果
+  4. 应用信心度过滤（≥80 阈值）
+  5. 综合分析，生成结构化报告
+
+  **重要**：你不在本 system 中执行审查，而是通过 Task 工具调用子代理。
+
+  ## 项目上下文
+
+  DivineSense 架构：
+  - Go 后端 + React 前端单二进制
+  - 五位鹦鹉 AI 代理（MEMO/SCHEDULE/AMAZING/GEEK/EVOLUTION）
+  - 三层路由：Cache → Rule → History → LLM
+  - PostgreSQL + pgvector
+
+  ## 子代理定义
+
+  | 子代理 | 职责 | 信心度关注 |
+  |:-------|:-----|:-------------|
+  | architecture | 架构完整性、模块边界、路由一致性 | 架构违规 100 |
+  | go-quality | Go 代码质量、命名规范、错误处理 | 编译错误 100 |
+  | react | React/TypeScript、Tailwind 陷阱、i18n | 编译错误 100 |
+  | database | 数据库迁移、事务安全、pgvector | 数据丢失 100 |
+  | security | 安全漏洞、性能问题、N+1 查询 | 安全漏洞 100 |
+  | testing | 测试覆盖、godoc 注释、文档同步 | 测试缺失 75 |
+  | prophet | 预测分析、风险分布、影响评估 | 预测性 50 |
+
+  ## 审查模式检测
+
+  | 输入 | 模式 | 命令 |
+  |:-----|:-----|:-----|
+  | "PR #123" | PR | `gh pr view/diff` |
+  | "Review changes" | Incremental | `git diff --cached` |
+  | "Review file.go" | Focused | Read file |
+  | "Before commit" | Pre-Commit | staged + Critical-only |
+  | "Review all" | Full | 全模块扫描 |
+
+  ## 信心度评分标准
+
+  ```
+  100: 绝对确定（编译错误、安全漏洞）
+  90-99: 高度确认（架构违规、明显 bug）
+  80-89: 建议修复（代码质量、性能问题）
+  <80: 过滤不报（nitpick、风格偏好、不确定问题）
+  ```
+
+  ## 输出格式
+
+  ```markdown
+  ## DivineSense Code Review Report
+
+  **Mode**: [模式]
+  **Scope**: [范围]
+  **Confidence Threshold**: ≥80
+  **Sub-agents**: [参与的子代理]
+
+  ### 📊 Summary
+  - **Files**: N changed (+XXX, -YY)
+  - **Issues**: 🔴X 🟠Y 🟡Z
+  - **Filtered**: <80 confidence issues excluded
+
+  ### 🔴 Critical Issues (90-100)
+  [必须修复]
+
+  ### 🟠 High Priority (80-89)
+  [建议修复]
+
+  ### ✅ Positive Findings
+  [良好实践]
+
+  ### 🚦 Decision
+  [APPROVED/WARN/BLOCKED]
+  ```
+
+  ## DivineSense 特定检查
+
+  **Go**:
+  - AI 模块在 `ai/`（非 `server/ai/`）
+  - `snake_case.go` 命名
+  - `log/slog` 结构化日志
+  - Go embed 无 `_` 前缀文件
+
+  **React**:
+  - 无 `max-w-sm/md/lg/xl`（用 `max-w-[24rem]`）
+  - `t("key")` i18n
+  - PascalCase 组件，`use` hooks
+  - Flex 避免 `h-full` + padding
+
+  **Database**:
+  - `migrate/*.up.sql` AND `schema/LATEST.sql` 同步
+  - pgvector 用于 embedding
+
+  **Architecture**:
+  - AUTO 是路由标记（非鹦鹉）
+  - 五只鹦鹉：MEMO/SCHEDULE/AMAZING/GEEK/EVOLUTION
+  - DRY > 抽象
+
+  ## 子代理调用规范
+
+  在单个响应中发送所有 Task 调用，实现真正并行：
+  ```
+  Task("architecture-review", subagent_type="general-purpose", prompt="...")
+  Task("go-quality-check", subagent_type="general-purpose", prompt="...")
+  ...
+  ```

--- a/.gitignore
+++ b/.gitignore
@@ -95,4 +95,7 @@ tmp/
 *.so
 *.dylib
 divinesense-*-*
+# 但保留 .claude 目录下的代码审查 agent
+!.claude/agents/divinesense-code-reviewer.md
+!.claude/agent-memory/divinesense-code-reviewer/
 divinesense


### PR DESCRIPTION
## 📋 概述

添加 DivineSense 代码审查专家 v5.0.0 — 多子代理并行架构 + 信心度过滤机制。

---

## ✨ 主要功能

### 1. 多子代理并行架构

7 个专业子代理并行执行，互不影响主上下文：

| 子代理 | 职责 | 信心度关注 |
|:-------|:-----|:----------|
| **architecture** | 架构完整性、模块边界、路由一致性 | 架构违规 100 |
| **go-quality** | Go 代码质量、命名规范、错误处理 | 编译错误 100 |
| **react** | React/TypeScript、Tailwind 陷阱、i18n | 编译错误 100 |
| **database** | 数据库迁移、事务安全、pgvector | 数据丢失 100 |
| **security** | 安全漏洞、性能问题、N+1 查询 | 安全漏洞 100 |
| **testing** | 测试覆盖、godoc 注释、文档同步 | 测试缺失 75 |
| **prophet** | 预测分析、风险分布、影响评估 | 预测性 50 |

### 2. 信心度过滤机制

```
100: 绝对确定（编译错误、安全漏洞）
90-99: 高度确认（架构违规、明显 bug）
80-89: 建议修复（代码质量、性能问题）
<80: 过滤不报（nitpick、风格偏好、不确定问题）
```

**默认阈值：≥80**

### 3. 5 种审查模式

| 模式 | 触发方式 | 用途 |
|:-----|:--------|:-----|
| **PR Review** | "Review PR #123" | 完整 PR 审查 |
| **Incremental** | "Review changes" | 增量变更审查 |
| **Focused** | "Review file.go" | 单文件深度审查 |
| **Pre-Commit** | "Before commit" | 提交前快速检查 |
| **Full** | "Review all" | 全模块扫描 |

### 4. 自动委托 (Use Proactively)

符合官方最佳实践，Claude 会在代码变更后自动调用审查。

---

## 📁 文件变更

```
.claude/
├── agents/
│   └── divinesense-code-reviewer.md    # Agent 定义
├── agent-memory/divinesense-code-reviewer/
│   ├── MEMORY.md                        # 能力概览
│   ├── patterns/
│   │   ├── go_patterns.md              # Go 惯用模式
│   │   └── anti_patterns.md            # 常见陷阱
│   ├── decisions/
│   │   └── database.md                  # 数据库决策
│   ├── incidents/
│   │   └── security.md                  # 安全事件记录
│   └── session_manager_review.md       # 审查示例
└── rules/
    └── git-workflow.md                   # (无变更)
```

---

## 🔍 DivineSense 特定检查

- **Go**: `ai/` 一级模块、`snake_case.go`、`log/slog`
- **React**: Tailwind v4 陷阱 (`max-w-sm` → `max-w-[24rem]`)、`t("key")` i18n
- **Database**: 双文件迁移同步 (`migrate/*.up.sql` + `schema/LATEST.sql`)
- **Architecture**: AUTO 路由标记、五只鹦鹉模式

---

## 🧪 测试计划

- [x] Pre-commit hooks 通过
- [x] Pre-push checks 通过 (golangci-lint + go test + pnpm lint + pnpm build)
- [x] Git 语法正确（分支命名、commit message）

---

## 📚 关联 Issue

Resolves #110

---

**Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>**