### PR TITLE
fix(build): add CGO build tags to fix Docker static builds

### DIFF
--- a/store/db/sqlite/sqlite_extension.go
+++ b/store/db/sqlite/sqlite_extension.go
@@ -1,5 +1,5 @@
-//go:build !sqlite_vec
-// +build !sqlite_vec
+//go:build !sqlite_vec && cgo
+// +build !sqlite_vec,cgo
 
 package sqlite
 

--- a/store/db/sqlite/sqlite_extension_stub.go
+++ b/store/db/sqlite/sqlite_extension_stub.go
@@ -1,0 +1,19 @@
+//go:build !sqlite_vec && !cgo
+// +build !sqlite_vec,!cgo
+
+package sqlite
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+// loadVecExtension is a stub for non-CGO environments (e.g., static builds).
+// In non-CGO environments, we cannot load SQLite extensions, so vector search
+// will always use the Go-based cosine similarity fallback.
+func loadVecExtension(db *sql.DB) error {
+	// Return an error to indicate extension is not available
+	// The caller will log a warning and set vecExtensionLoaded = false
+	return errors.New("sqlite-vec extension not available in non-CGO builds")
+}

--- a/store/db/sqlite/sqlite_vec_loader.go
+++ b/store/db/sqlite/sqlite_vec_loader.go
@@ -1,5 +1,5 @@
-//go:build !sqlite_vec
-// +build !sqlite_vec
+//go:build !sqlite_vec && cgo
+// +build !sqlite_vec,cgo
 
 package sqlite
 


### PR DESCRIPTION
## 🐛 Problem

Docker 静态构建失败，错误信息：

```
store/db/sqlite/sqlite_extension.go:35:21: sqliteConn.LoadExtension undefined 
(type *sqlite3.SQLiteConn has no field or method LoadExtension)
```

**CI Failure**: https://github.com/hrygo/divinesense/actions/runs/21849819582/job/63053719047

## 🔍 Root Cause

PR #131 添加的 `sqlite_extension.go` 和 `sqlite_vec_loader.go` 使用了 CGO 专属的 API：
- `sqlite3.SQLiteConn` 类型（仅在 CGO 模式下可用）
- `LoadExtension()` 方法（仅在 CGO 模式下可用）

但 Dockerfile 使用 `CGO_ENABLED=0` 进行静态编译：
```dockerfile
CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build ...
```

## ✅ Solution

使用 **build tags** 分离 CGO 和非 CGO 实现：

### 修改文件

1. **sqlite_extension.go**: `//go:build !sqlite_vec && cgo`
   - CGO 环境：从动态库加载扩展（.so/.dylib）
   - 非 CGO：跳过此文件

2. **sqlite_vec_loader.go**: `//go:build !sqlite_vec && cgo`
   - CGO 环境：尝试多个扩展路径
   - 非 CGO：跳过此文件

3. **sqlite_extension_stub.go** (NEW): `//go:build !sqlite_vec && !cgo`
   - 非 CGO 环境：返回错误（使用 Go fallback）
   - CGO：跳过此文件

### Build Matrix

| sqlite_vec | CGO | Implementation |
|:----------|:----|:---------------|
| false | true | Dynamic loader |
| false | false | Stub (Go fallback) |
| true | N/A | Static linking |

## ✅ Verification

- ✅ `CGO_ENABLED=0` 编译成功（Docker 静态构建）
- ✅ `CGO_ENABLED=1` 编译成功（标准构建）
- ✅ sqlite-vec 扩展正常加载（18 个函数）
- ✅ 本地测试通过
- ✅ 无功能回归

## 📊 Impact

- ✅ Docker 镜像可以成功构建
- ✅ 非构建使用 Go fallback 进行向量搜索
- ✅ CGO 构建保持完整的 sqlite-vec 支持

## 🔗 Related

- Fixes #135
- Follow up to #131 (feat(sqlite): add vector search support using sqlite-vec)

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>