### PR TITLE
feat(ui): unified sidebar collapse + FixedEditor collapse

### DIFF
--- a/web/src/components/AIChat/ChatHeader.tsx
+++ b/web/src/components/AIChat/ChatHeader.tsx
@@ -1,4 +1,4 @@
-import { Maximize2, Minimize2, Sparkles } from "lucide-react";
+import { Sparkles } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { AnimatedAvatar } from "@/components/AIChat/AnimatedAvatar";
@@ -15,8 +15,6 @@ interface ChatHeaderProps {
   currentCapability?: CapabilityType;
   capabilityStatus?: CapabilityStatus;
   currentMode?: AIMode;
-  immersiveMode?: boolean;
-  onImmersiveModeToggle?: (enabled: boolean) => void;
   /** Phase 4: Blocks for session stats display */
   blocks?: AIBlock[];
 }
@@ -139,8 +137,6 @@ export function ChatHeader({
   currentCapability = CapabilityType.AUTO,
   capabilityStatus = "idle",
   currentMode = "normal",
-  immersiveMode = false,
-  onImmersiveModeToggle,
   blocks,
 }: ChatHeaderProps) {
   const { t } = useTranslation();
@@ -190,25 +186,12 @@ export function ChatHeader({
         </div>
       </div>
 
-      {/* Right Section - Session Stats + Immersive Toggle + Thinking indicator */}
+      {/* Right Section - Session Stats + Thinking indicator */}
       <div className="flex items-center gap-2">
         {/* Session Stats - PC only */}
         <HeaderSessionStats blocks={blocks} mode={currentMode} />
 
-        {/* Immersive Mode Toggle - Desktop only */}
-        {onImmersiveModeToggle && (
-          <button
-            onClick={() => onImmersiveModeToggle(!immersiveMode)}
-            className={cn(
-              "hidden lg:flex items-center justify-center w-8 h-8 rounded-lg transition-all",
-              "text-muted-foreground hover:text-foreground hover:bg-muted",
-              immersiveMode && "text-primary bg-primary/10",
-            )}
-            title={immersiveMode ? t("ai.exit-immersive") : t("ai.enter-immersive")}
-          >
-            {immersiveMode ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
-          </button>
-        )}
+        {/* Thinking indicator */}
         {isThinking && (
           <div className="flex items-center gap-1.5 text-sm">
             <Sparkles className={cn("w-4 h-4 animate-pulse", modeStyle.thinking)} />

--- a/web/src/components/ui/SidebarCollapseButton.tsx
+++ b/web/src/components/ui/SidebarCollapseButton.tsx
@@ -1,0 +1,82 @@
+/**
+ * SidebarCollapseButton - 侧边栏收起按钮
+ *
+ * 设计哲学：「禅意智识 · 意识之镜」
+ * - 简约：仅图标，无多余装饰
+ * - 温和：柔和的过渡动画
+ * - 状态感知：视觉反馈随状态变化
+ *
+ * 位置：侧边栏右边缘，垂直居中
+ */
+
+import { ChevronLeft } from "lucide-react";
+import { memo } from "react";
+import { cn } from "@/lib/utils";
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+export interface SidebarCollapseButtonProps {
+  /** 侧边栏是否展开 */
+  isExpanded: boolean;
+  /** 切换侧边栏状态 */
+  onToggle: () => void;
+  /** 额外的 className */
+  className?: string;
+  /** aria-label for accessibility */
+  expandLabel?: string;
+  collapseLabel?: string;
+}
+
+// ============================================================================
+// 主组件
+// ============================================================================
+
+export const SidebarCollapseButton = memo(function SidebarCollapseButton({
+  isExpanded,
+  onToggle,
+  className,
+  expandLabel = "Expand sidebar",
+  collapseLabel = "Collapse sidebar",
+}: SidebarCollapseButtonProps) {
+  return (
+    <button
+      onClick={onToggle}
+      className={cn(
+        // Positioning - fixed at sidebar right edge, vertically centered
+        // left-16 (64px) is the nav bar width
+        // w-80 (320px) is the sidebar width
+        // When expanded: left-[calc(4rem+320px-1px)] to sit at right edge
+        // When collapsed: left-[calc(4rem-1px)] to sit at nav bar right edge
+        "fixed top-1/2 -translate-y-1/2 z-40",
+        "transition-all duration-300 ease-out",
+        isExpanded ? "left-[calc(4rem+320px-1px)]" : "left-[calc(4rem-1px)]",
+        // Size and shape
+        "w-6 h-12 flex items-center justify-center",
+        // Background - subtle glass effect
+        "bg-background/80 backdrop-blur-sm",
+        // Border - rounded right side only
+        "border border-l-0 border-border/50 rounded-r-lg",
+        // Shadow
+        "shadow-sm hover:shadow-md",
+        // Text color
+        "text-muted-foreground hover:text-foreground",
+        // Hover and active states
+        "hover:bg-muted/50 active:scale-95",
+        // Focus visible for accessibility
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
+        className,
+      )}
+      aria-label={isExpanded ? collapseLabel : expandLabel}
+      title={isExpanded ? collapseLabel : expandLabel}
+    >
+      {/* Icon with rotation animation */}
+      <div className={cn("transition-transform duration-300 ease-out", isExpanded ? "rotate-0" : "rotate-180")}>
+        <ChevronLeft className="w-4 h-4" />
+      </div>
+    </button>
+  );
+});
+
+SidebarCollapseButton.displayName = "SidebarCollapseButton";

--- a/web/src/layouts/AIChatLayout.tsx
+++ b/web/src/layouts/AIChatLayout.tsx
@@ -1,11 +1,13 @@
 import { MenuIcon } from "lucide-react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Outlet } from "react-router-dom";
 import { AIChatSidebar } from "@/components/AIChat/AIChatSidebar";
 import { ModeThemeProvider } from "@/components/AIChat/ModeThemeProvider";
 import NavigationDrawer from "@/components/NavigationDrawer";
 import RouteHeaderImage from "@/components/RouteHeaderImage";
 import { Button } from "@/components/ui/button";
+import { SidebarCollapseButton } from "@/components/ui/SidebarCollapseButton";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { AIChatProvider, useAIChat } from "@/contexts/AIChatContext";
 import useMediaQuery from "@/hooks/useMediaQuery";
@@ -83,9 +85,10 @@ function getModeStyles(mode: AIMode) {
 }
 
 const AIChatLayoutContent = () => {
+  const { t } = useTranslation();
   const lg = useMediaQuery("lg");
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
-  const { state } = useAIChat();
+  const { state, toggleImmersiveMode } = useAIChat();
   const currentMode = state.currentMode || "normal";
   const immersiveMode = state.immersiveMode || false;
 
@@ -193,6 +196,16 @@ const AIChatLayoutContent = () => {
       >
         <Outlet />
       </div>
+
+      {/* Sidebar Collapse Button - Desktop only */}
+      {lg && (
+        <SidebarCollapseButton
+          isExpanded={!immersiveMode}
+          onToggle={() => toggleImmersiveMode(!immersiveMode)}
+          expandLabel={t("sidebar.expand")}
+          collapseLabel={t("sidebar.collapse")}
+        />
+      )}
     </section>
   );
 };

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -15,6 +15,10 @@
       "retry": "Retry Connection"
     }
   },
+  "sidebar": {
+    "collapse": "Collapse sidebar",
+    "expand": "Expand sidebar"
+  },
   "ai": {
     "aichat": {
       "amazing-insight": {
@@ -794,6 +798,8 @@
     "wed": "Wed"
   },
   "editor": {
+    "collapse": "Collapse editor",
+    "expand": "Expand editor",
     "chars": "chars",
     "add-your-comment-here": "Add your comment here...",
     "ai-tag": {

--- a/web/src/locales/zh-Hans.json
+++ b/web/src/locales/zh-Hans.json
@@ -15,6 +15,10 @@
       "retry": "重试连接"
     }
   },
+  "sidebar": {
+    "collapse": "收起侧边栏",
+    "expand": "展开侧边栏"
+  },
   "ai": {
     "aichat": {
       "amazing-insight": {
@@ -789,6 +793,8 @@
     "wed": "三"
   },
   "editor": {
+    "collapse": "收起编辑器",
+    "expand": "展开编辑器",
     "chars": "字符",
     "add-your-comment-here": "请输入您的评论...",
     "ai-tag": {

--- a/web/src/pages/AIChat.tsx
+++ b/web/src/pages/AIChat.tsx
@@ -49,8 +49,6 @@ interface UnifiedChatViewProps {
   upcomingScheduleCount?: number;
   currentMode: AIMode;
   onModeChange: (mode: AIMode) => void;
-  immersiveMode: boolean;
-  onImmersiveModeToggle: (enabled: boolean) => void;
   isAdmin?: boolean;
   conversationId?: number;
 }
@@ -75,8 +73,6 @@ function UnifiedChatView({
   upcomingScheduleCount,
   currentMode,
   onModeChange,
-  immersiveMode,
-  onImmersiveModeToggle,
   conversationId,
 }: UnifiedChatViewProps) {
   const { t } = useTranslation();
@@ -133,8 +129,6 @@ function UnifiedChatView({
         capabilityStatus={capabilityStatus}
         isThinking={isThinking}
         currentMode={currentMode}
-        immersiveMode={immersiveMode}
-        onImmersiveModeToggle={onImmersiveModeToggle}
         blocks={blocks}
       />
 
@@ -237,7 +231,6 @@ const AIChat = () => {
     setCurrentCapability,
     setCapabilityStatus,
     setMode,
-    toggleImmersiveMode,
     // Phase 4: Block methods
     appendUserInput,
     incrementMessageCount,
@@ -250,7 +243,6 @@ const AIChat = () => {
   const currentCapability = state.currentCapability || CapabilityType.AUTO;
   const capabilityStatus = state.capabilityStatus || "idle";
   const currentMode = state.currentMode || "normal";
-  const immersiveMode = state.immersiveMode || false;
 
   // ============================================================
   // Phase 4: Unified Block Model - Use blocks as primary data source
@@ -698,8 +690,6 @@ const AIChat = () => {
       capabilityStatus={capabilityStatus}
       currentMode={currentMode}
       onModeChange={setMode}
-      immersiveMode={immersiveMode}
-      onImmersiveModeToggle={toggleImmersiveMode}
       isAdmin={true}
       conversationId={currentConversationIdNum}
     />


### PR DESCRIPTION
## Summary
- 统一侧边栏收起交互：为 /memo, /chat, /schedule 添加一致的侧边栏收起按钮
- 移除页面右上角的最大化按钮（MemoLayout 和 AIChatLayout）
- FixedEditor 添加收起/展开功能（顶部居中按钮）

Resolves #195

## Changes

### 新增组件
- `SidebarCollapseButton` - 统一的侧边栏收起按钮，位于侧边栏右边缘

### Layout 改造
- **MemoLayout**: 移除右上角最大化按钮，添加 SidebarCollapseButton
- **AIChatLayout**: 添加 SidebarCollapseButton，移除 ChatHeader 中的最大化按钮
- **ScheduleLayout**: 新增侧边栏收起功能 + SidebarCollapseButton

### FixedEditor 改造
- 添加 `isCollapsed` 状态（localStorage 持久化）
- 顶部居中收起按钮（ChevronDown 图标）
- 收起后显示迷你触发器（顶部居中，圆形图标，呼吸动画）

### i18n 更新
- `sidebar.collapse` / `sidebar.expand`
- `editor.collapse` / `editor.expand`

## Test plan
- [ ] /memo 页面侧边栏收起/展开功能正常
- [ ] /chat 页面侧边栏收起/展开功能正常
- [ ] /schedule 页面侧边栏收起/展开功能正常
- [ ] FixedEditor 收起/展开功能正常
- [ ] 收起状态持久化到 localStorage
- [ ] i18n 双语显示正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)