### PR TITLE
feat(ai): 实现 Expert Agent Handoff 机制 (#198)

### DIFF
--- a/ai/agents/orchestrator/capability_map.go
+++ b/ai/agents/orchestrator/capability_map.go
@@ -1,0 +1,151 @@
+// Package orchestrator implements the Orchestrator-Workers pattern for multi-agent coordination.
+// It uses LLM to dynamically decompose tasks, dispatch to expert agents, and aggregate results.
+package orchestrator
+
+import (
+	"strings"
+	"sync"
+
+	agents "github.com/hrygo/divinesense/ai/agents"
+)
+
+// Capability represents a single capability that an expert agent can provide.
+// Capability represents a single capability that an expert agent can provide.
+type Capability string
+
+// ExpertInfo contains information about an expert agent.
+// ExpertInfo 包含专家代理的信息。
+type ExpertInfo struct {
+	Name         string   `json:"name"`
+	Emoji        string   `json:"emoji"`
+	Title        string   `json:"title"`
+	Capabilities []string `json:"capabilities"`
+}
+
+// CapabilityMap provides a thread-safe mapping from capabilities to expert agents.
+// It is used at runtime to build the capability-to-expert mapping.
+type CapabilityMap struct {
+	mu                  sync.RWMutex
+	capabilityToExperts map[Capability][]*ExpertInfo
+	experts             map[string]*ExpertInfo
+}
+
+// NewCapabilityMap creates an empty CapabilityMap.
+// NewCapabilityMap 创建一个空的 CapabilityMap。
+func NewCapabilityMap() *CapabilityMap {
+	return &CapabilityMap{
+		capabilityToExperts: make(map[Capability][]*ExpertInfo),
+		experts:             make(map[string]*ExpertInfo),
+	}
+}
+
+// BuildFromConfigs builds the capability map from ParrotSelfCognition configurations.
+// BuildFromConfigs 从 ParrotSelfCognition 配置构建能力映射。
+func (cm *CapabilityMap) BuildFromConfigs(configs []*agents.ParrotSelfCognition) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	// Clear existing mappings
+	cm.capabilityToExperts = make(map[Capability][]*ExpertInfo)
+	cm.experts = make(map[string]*ExpertInfo)
+
+	for _, config := range configs {
+		if config == nil {
+			continue
+		}
+
+		expert := &ExpertInfo{
+			Name:         config.Name,
+			Emoji:        config.Emoji,
+			Title:        config.Title,
+			Capabilities: config.Capabilities,
+		}
+
+		// Add to experts map
+		cm.experts[config.Name] = expert
+
+		// Add to capabilityToExperts map
+		for _, cap := range config.Capabilities {
+			normalizedCap := cm.normalizeCapability(cap)
+			if normalizedCap == "" {
+				continue
+			}
+			cm.capabilityToExperts[Capability(normalizedCap)] = append(
+				cm.capabilityToExperts[Capability(normalizedCap)],
+				expert,
+			)
+		}
+	}
+}
+
+// FindExpertsByCapability returns all experts that provide the given capability.
+// FindExpertsByCapability 返回提供指定能力的所有专家。
+func (cm *CapabilityMap) FindExpertsByCapability(capability string) []*ExpertInfo {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	normalizedCap := cm.normalizeCapability(capability)
+	if normalizedCap == "" {
+		return nil
+	}
+
+	experts, ok := cm.capabilityToExperts[Capability(normalizedCap)]
+	if !ok {
+		return nil
+	}
+
+	// Return a copy to avoid external mutation
+	result := make([]*ExpertInfo, len(experts))
+	copy(result, experts)
+	return result
+}
+
+// FindAlternativeExperts returns all experts that provide the given capability,
+// excluding the specified expert. This is useful for finding fallback experts.
+// FindAlternativeExperts 返回提供指定能力的所有专家，但排除指定的专家。
+// 这在寻找备用专家时很有用。
+func (cm *CapabilityMap) FindAlternativeExperts(capability string, excludeExpert string) []*ExpertInfo {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	normalizedCap := cm.normalizeCapability(capability)
+	if normalizedCap == "" {
+		return nil
+	}
+
+	experts, ok := cm.capabilityToExperts[Capability(normalizedCap)]
+	if !ok {
+		return nil
+	}
+
+	// Filter out the excluded expert
+	var result []*ExpertInfo
+	for _, expert := range experts {
+		if expert.Name != excludeExpert {
+			result = append(result, expert)
+		}
+	}
+
+	return result
+}
+
+// GetAllExperts returns all registered experts.
+// GetAllExperts 返回所有已注册的专家。
+func (cm *CapabilityMap) GetAllExperts() []*ExpertInfo {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	experts := make([]*ExpertInfo, 0, len(cm.experts))
+	for _, expert := range cm.experts {
+		experts = append(experts, expert)
+	}
+	return experts
+}
+
+// normalizeCapability normalizes a capability string for consistent lookup.
+// It converts the capability to lowercase and trims whitespace.
+// normalizeCapability 标准化能力字符串以进行一致的查找。
+// 它将能力转换为小写并去除空白。
+func (cm *CapabilityMap) normalizeCapability(cap string) string {
+	return strings.ToLower(strings.TrimSpace(cap))
+}

--- a/ai/agents/orchestrator/capability_map_test.go
+++ b/ai/agents/orchestrator/capability_map_test.go
@@ -1,0 +1,306 @@
+package orchestrator
+
+import (
+	"testing"
+
+	agents "github.com/hrygo/divinesense/ai/agents"
+)
+
+func TestCapabilityMap_NewCapabilityMap(t *testing.T) {
+	cm := NewCapabilityMap()
+	if cm == nil {
+		t.Fatal("NewCapabilityMap should not return nil")
+	}
+	if cm.capabilityToExperts == nil {
+		t.Error("capabilityToExperts should be initialized")
+	}
+	if cm.experts == nil {
+		t.Error("experts should be initialized")
+	}
+}
+
+func TestCapabilityMap_BuildFromConfigs(t *testing.T) {
+	tests := []struct {
+		name         string
+		configs      []*agents.ParrotSelfCognition
+		expectedCaps int
+		expectedExps int
+	}{
+		{
+			name: "single expert with multiple capabilities",
+			configs: []*agents.ParrotSelfCognition{
+				{
+					Name:  "memo",
+					Emoji: "📝",
+					Title: "Note Expert",
+					Capabilities: []string{
+						"search_notes",
+						"create_note",
+						"edit_note",
+					},
+				},
+			},
+			expectedCaps: 3,
+			expectedExps: 1,
+		},
+		{
+			name: "multiple experts with overlapping capabilities",
+			configs: []*agents.ParrotSelfCognition{
+				{
+					Name:         "memo",
+					Emoji:        "📝",
+					Title:        "Note Expert",
+					Capabilities: []string{"search_notes", "create_note"},
+				},
+				{
+					Name:         "schedule",
+					Emoji:        "📅",
+					Title:        "Schedule Expert",
+					Capabilities: []string{"search_notes", "create_event"},
+				},
+			},
+			expectedCaps: 3, // search_notes, create_note, create_event
+			expectedExps: 2,
+		},
+		{
+			name:         "nil configs",
+			configs:      nil,
+			expectedCaps: 0,
+			expectedExps: 0,
+		},
+		{
+			name: "empty configs",
+			configs: []*agents.ParrotSelfCognition{
+				nil,
+			},
+			expectedCaps: 0,
+			expectedExps: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := NewCapabilityMap()
+			cm.BuildFromConfigs(tt.configs)
+
+			// Check experts count
+			experts := cm.GetAllExperts()
+			if len(experts) != tt.expectedExps {
+				t.Errorf("expected %d experts, got %d", tt.expectedExps, len(experts))
+			}
+
+			// Check capability count (capabilityToExperts map)
+			if tt.expectedCaps > 0 && len(cm.capabilityToExperts) != tt.expectedCaps {
+				t.Errorf("expected %d capabilities, got %d", tt.expectedCaps, len(cm.capabilityToExperts))
+			}
+		})
+	}
+}
+
+func TestCapabilityMap_FindExpertsByCapability(t *testing.T) {
+	cm := NewCapabilityMap()
+	cm.BuildFromConfigs([]*agents.ParrotSelfCognition{
+		{
+			Name:         "memo",
+			Emoji:        "📝",
+			Title:        "Note Expert",
+			Capabilities: []string{"search_notes", "create_note"},
+		},
+		{
+			Name:         "schedule",
+			Emoji:        "📅",
+			Title:        "Schedule Expert",
+			Capabilities: []string{"search_notes", "create_event"},
+		},
+		{
+			Name:         "geek",
+			Emoji:        "🤖",
+			Title:        "Tech Expert",
+			Capabilities: []string{"execute_code"},
+		},
+	})
+
+	tests := []struct {
+		name          string
+		capability    string
+		expectedCount int
+		expectedNames []string
+	}{
+		{
+			name:          "search_notes - should find memo and schedule",
+			capability:    "search_notes",
+			expectedCount: 2,
+			expectedNames: []string{"memo", "schedule"},
+		},
+		{
+			name:          "create_note - should find only memo",
+			capability:    "create_note",
+			expectedCount: 1,
+			expectedNames: []string{"memo"},
+		},
+		{
+			name:          "execute_code - should find only geek",
+			capability:    "execute_code",
+			expectedCount: 1,
+			expectedNames: []string{"geek"},
+		},
+		{
+			name:          "non_existent - should return nil",
+			capability:    "non_existent",
+			expectedCount: 0,
+			expectedNames: nil,
+		},
+		{
+			name:          "case insensitive - SEARCH_NOTES",
+			capability:    "SEARCH_NOTES",
+			expectedCount: 2,
+			expectedNames: []string{"memo", "schedule"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			experts := cm.FindExpertsByCapability(tt.capability)
+			if len(experts) != tt.expectedCount {
+				t.Errorf("expected %d experts, got %d", tt.expectedCount, len(experts))
+			}
+
+			if tt.expectedNames != nil {
+				for i, exp := range experts {
+					if i >= len(tt.expectedNames) {
+						break
+					}
+					if exp.Name != tt.expectedNames[i] {
+						t.Errorf("expected expert %s at index %d, got %s", tt.expectedNames[i], i, exp.Name)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCapabilityMap_FindAlternativeExperts(t *testing.T) {
+	cm := NewCapabilityMap()
+	cm.BuildFromConfigs([]*agents.ParrotSelfCognition{
+		{
+			Name:         "memo",
+			Emoji:        "📝",
+			Title:        "Note Expert",
+			Capabilities: []string{"search_notes", "create_note"},
+		},
+		{
+			Name:         "schedule",
+			Emoji:        "📅",
+			Title:        "Schedule Expert",
+			Capabilities: []string{"search_notes", "create_event"},
+		},
+	})
+
+	tests := []struct {
+		name          string
+		capability    string
+		excludeExpert string
+		expectedCount int
+		expectedNames []string
+	}{
+		{
+			name:          "exclude memo from search_notes",
+			capability:    "search_notes",
+			excludeExpert: "memo",
+			expectedCount: 1,
+			expectedNames: []string{"schedule"},
+		},
+		{
+			name:          "exclude schedule from search_notes",
+			capability:    "search_notes",
+			excludeExpert: "schedule",
+			expectedCount: 1,
+			expectedNames: []string{"memo"},
+		},
+		{
+			name:          "exclude non_existent expert",
+			capability:    "search_notes",
+			excludeExpert: "non_existent",
+			expectedCount: 2,
+			expectedNames: []string{"memo", "schedule"},
+		},
+		{
+			name:          "capability not found",
+			capability:    "non_existent",
+			excludeExpert: "memo",
+			expectedCount: 0,
+			expectedNames: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			experts := cm.FindAlternativeExperts(tt.capability, tt.excludeExpert)
+			if len(experts) != tt.expectedCount {
+				t.Errorf("expected %d experts, got %d", tt.expectedCount, len(experts))
+			}
+
+			if tt.expectedNames != nil {
+				for i, exp := range experts {
+					if i >= len(tt.expectedNames) {
+						break
+					}
+					if exp.Name != tt.expectedNames[i] {
+						t.Errorf("expected expert %s at index %d, got %s", tt.expectedNames[i], i, exp.Name)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCapabilityMap_GetAllExperts(t *testing.T) {
+	cm := NewCapabilityMap()
+	cm.BuildFromConfigs([]*agents.ParrotSelfCognition{
+		{
+			Name:         "memo",
+			Emoji:        "📝",
+			Title:        "Note Expert",
+			Capabilities: []string{"search_notes"},
+		},
+		{
+			Name:         "schedule",
+			Emoji:        "📅",
+			Title:        "Schedule Expert",
+			Capabilities: []string{"create_event"},
+		},
+	})
+
+	experts := cm.GetAllExperts()
+	if len(experts) != 2 {
+		t.Errorf("expected 2 experts, got %d", len(experts))
+	}
+
+	// Verify it returns a new slice each time (not the same slice reference)
+	experts2 := cm.GetAllExperts()
+	if &experts[0] == &experts2[0] {
+		t.Error("GetAllExperts should return a new slice, not the same slice reference")
+	}
+}
+
+func TestCapabilityMap_normalizeCapability(t *testing.T) {
+	cm := NewCapabilityMap()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"SEARCH_NOTES", "search_notes"},
+		{"  search_notes  ", "search_notes"},
+		{"Search_Notes", "search_notes"},
+		{"", ""},
+		{"   ", ""},
+	}
+
+	for _, tt := range tests {
+		result := cm.normalizeCapability(tt.input)
+		if result != tt.expected {
+			t.Errorf("normalizeCapability(%q) = %q, expected %q", tt.input, result, tt.expected)
+		}
+	}
+}

--- a/ai/agents/orchestrator/executor.go
+++ b/ai/agents/orchestrator/executor.go
@@ -21,8 +21,9 @@ const (
 
 // Executor executes tasks by dispatching them to expert agents.
 type Executor struct {
-	registry ExpertRegistry
-	config   *OrchestratorConfig
+	registry       ExpertRegistry
+	config         *OrchestratorConfig
+	handoffHandler *HandoffHandler
 }
 
 // NewExecutor creates a new task executor.
@@ -31,8 +32,21 @@ func NewExecutor(registry ExpertRegistry, config *OrchestratorConfig) *Executor 
 		config = DefaultOrchestratorConfig()
 	}
 	return &Executor{
-		registry: registry,
-		config:   config,
+		registry:       registry,
+		config:         config,
+		handoffHandler: nil,
+	}
+}
+
+// NewExecutorWithHandoff creates a new task executor with handoff support.
+func NewExecutorWithHandoff(registry ExpertRegistry, config *OrchestratorConfig, handoffHandler *HandoffHandler) *Executor {
+	if config == nil {
+		config = DefaultOrchestratorConfig()
+	}
+	return &Executor{
+		registry:       registry,
+		config:         config,
+		handoffHandler: handoffHandler,
 	}
 }
 
@@ -163,6 +177,26 @@ func (e *Executor) executeTask(ctx context.Context, task *Task, index int, callb
 			"index", index,
 			"agent", task.Agent,
 			"error", err)
+
+		// Try handoff if handler is available
+		if e.handoffHandler != nil {
+			handoffResult := e.handoffHandler.HandleTaskFailure(ctx, task, err, callback)
+			if handoffResult.Success && handoffResult.NewTask != nil {
+				slog.Info("executor: attempting handoff",
+					"task", task.ID,
+					"from", task.Agent,
+					"to", handoffResult.NewExpert)
+
+				// Execute with new expert
+				task.Agent = handoffResult.NewExpert
+				task.Input = handoffResult.NewTask.Input
+				task.Status = TaskStatusPending
+
+				// Re-execute the task with new expert
+				e.executeTask(ctx, task, index, callback)
+				return
+			}
+		}
 	} else {
 		task.Status = TaskStatusCompleted
 		task.Result = resultCollector.getResult()

--- a/ai/agents/orchestrator/handoff.go
+++ b/ai/agents/orchestrator/handoff.go
@@ -1,0 +1,284 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+)
+
+// Handoff event types
+const (
+	// EventTypeCannotComplete indicates an expert cannot complete the task.
+	EventTypeCannotComplete = "cannot_complete"
+	// EventTypeHandoffStart indicates a handoff has started.
+	EventTypeHandoffStart = "handoff_start"
+	// EventTypeHandoffEnd indicates a handoff has completed.
+	EventTypeHandoffEnd = "handoff_end"
+)
+
+// CannotCompleteReason defines reasons why an expert cannot complete a task.
+type CannotCompleteReason struct {
+	// MissingCapabilities lists capabilities that the expert lacks.
+	MissingCapabilities []string `json:"missing_capabilities"`
+	// OriginalError is the original error message from the expert.
+	OriginalError string `json:"original_error"`
+	// SuggestedExpert is an optional hint about which expert might help.
+	SuggestedExpert string `json:"suggested_expert,omitempty"`
+}
+
+// HandoffResult contains the result of a handoff operation.
+type HandoffResult struct {
+	// Success indicates whether the handoff was successful.
+	Success bool `json:"success"`
+	// NewExpert is the name of the expert that took over (if successful).
+	NewExpert string `json:"new_expert,omitempty"`
+	// NewTask is the new task created for the alternative expert (if any).
+	NewTask *Task `json:"new_task,omitempty"`
+	// Error is the error message if handoff failed.
+	Error string `json:"error,omitempty"`
+	// Attempts records the number of handoff attempts.
+	Attempts int `json:"attempts"`
+}
+
+// HandoffHandler handles the handoff of tasks between expert agents.
+type HandoffHandler struct {
+	capabilityMap *CapabilityMap
+	maxAttempts   int
+}
+
+// NewHandoffHandler creates a new HandoffHandler.
+func NewHandoffHandler(capabilityMap *CapabilityMap, maxAttempts int) *HandoffHandler {
+	if maxAttempts <= 0 {
+		maxAttempts = 2 // Default max handoff attempts
+	}
+	return &HandoffHandler{
+		capabilityMap: capabilityMap,
+		maxAttempts:   maxAttempts,
+	}
+}
+
+// HandleCannotComplete processes a cannot_complete event and determines next action.
+func (h *HandoffHandler) HandleCannotComplete(
+	ctx context.Context,
+	task *Task,
+	reason CannotCompleteReason,
+	callback EventCallback,
+) *HandoffResult {
+
+	slog.Info("handoff: processing cannot_complete",
+		"task_id", task.ID,
+		"agent", task.Agent,
+		"missing", reason.MissingCapabilities)
+
+	result := &HandoffResult{
+		Attempts: 1,
+	}
+
+	// Try to find an alternative expert for each missing capability
+	for _, cap := range reason.MissingCapabilities {
+		alternatives := h.capabilityMap.FindAlternativeExperts(cap, task.Agent)
+
+		if len(alternatives) == 0 {
+			slog.Warn("handoff: no alternative expert found",
+				"capability", cap,
+				"current_expert", task.Agent)
+			continue
+		}
+
+		// Select the first available alternative
+		selectedExpert := alternatives[0]
+
+		// Send handoff_start event
+		if callback != nil {
+			h.sendHandoffStartEvent(task, selectedExpert, cap, callback)
+		}
+
+		// Create new task for the alternative expert
+		newTask, err := NewTask(
+			selectedExpert.Name,
+			task.Input,
+			task.Purpose,
+		)
+		if err != nil {
+			result.Error = err.Error()
+			return result
+		}
+
+		result.Success = true
+		result.NewExpert = selectedExpert.Name
+		result.NewTask = newTask
+
+		slog.Info("handoff: created new task",
+			"original_task", task.ID,
+			"new_task", newTask.ID,
+			"new_expert", selectedExpert.Name)
+
+		// Send handoff_end event
+		if callback != nil {
+			h.sendHandoffEndEvent(task, result, callback)
+		}
+
+		return result
+	}
+
+	result.Error = "no suitable expert found for missing capabilities"
+	return result
+}
+
+// HandleTaskFailure handles task failure and determines if handoff is appropriate.
+func (h *HandoffHandler) HandleTaskFailure(
+	ctx context.Context,
+	task *Task,
+	err error,
+	callback EventCallback,
+) *HandoffResult {
+
+	// Analyze the error to determine if handoff is appropriate
+	reason := h.analyzeFailureReason(task.Agent, err)
+
+	// If no clear missing capabilities, return failure
+	if len(reason.MissingCapabilities) == 0 {
+		return &HandoffResult{
+			Success: false,
+			Error:   err.Error(),
+		}
+	}
+
+	return h.HandleCannotComplete(ctx, task, reason, callback)
+}
+
+// analyzeFailureReason analyzes an error to determine missing capabilities.
+// This is a simple keyword-based implementation that can be extended
+// with LLM-based analysis for more sophisticated error understanding.
+func (h *HandoffHandler) analyzeFailureReason(_ string, err error) CannotCompleteReason {
+	errMsg := err.Error()
+	reason := CannotCompleteReason{
+		OriginalError: errMsg,
+	}
+
+	// Keyword to capability mapping
+	// These keywords indicate which capabilities might be needed
+	capabilityKeywords := map[string][]string{
+		// Schedule-related keywords
+		"日程":       {"日程管理", "创建日程", "calendar", "schedule", "event", "会议", "安排"},
+		"安排":       {"日程管理", "创建日程", "calendar", "schedule", "event"},
+		"calendar": {"日程管理", "calendar", "schedule"},
+		"schedule": {"日程管理", "calendar", "schedule"},
+		"会议":       {"日程管理", "创建日程", "calendar", "schedule"},
+
+		// Memo-related keywords
+		"笔记":   {"笔记搜索", "搜索笔记", "note", "memo", "文档"},
+		"搜索":   {"笔记搜索", "搜索笔记", "note", "memo", "文档"},
+		"note": {"笔记搜索", "note", "memo"},
+		"memo": {"笔记搜索", "note", "memo"},
+		"文档":   {"笔记搜索", "note", "memo", "文档"},
+
+		// Generic "cannot handle" patterns
+		"无法处理":                {},
+		"cannot handle":       {},
+		"unable to":           {},
+		"不在能力范围内":             {},
+		"超出能力":                {},
+		"not in capabilities": {},
+	}
+
+	for keyword, caps := range capabilityKeywords {
+		if strings.Contains(strings.ToLower(errMsg), strings.ToLower(keyword)) {
+			reason.MissingCapabilities = append(reason.MissingCapabilities, caps...)
+		}
+	}
+
+	// Remove duplicates
+	if len(reason.MissingCapabilities) > 0 {
+		seen := make(map[string]bool)
+		var unique []string
+		for _, cap := range reason.MissingCapabilities {
+			if !seen[cap] {
+				seen[cap] = true
+				unique = append(unique, cap)
+			}
+		}
+		reason.MissingCapabilities = unique
+	}
+
+	return reason
+}
+
+// sendHandoffStartEvent sends a handoff_start event to the frontend.
+func (h *HandoffHandler) sendHandoffStartEvent(
+	originalTask *Task,
+	newExpert *ExpertInfo,
+	capability string,
+	callback EventCallback,
+) {
+	event := map[string]interface{}{
+		"original_task":  originalTask.ID,
+		"original_agent": originalTask.Agent,
+		"new_agent":      newExpert.Name,
+		"capability":     capability,
+	}
+	h.sendEvent(EventTypeHandoffStart, event, callback)
+}
+
+// sendHandoffEndEvent sends a handoff_end event to the frontend.
+func (h *HandoffHandler) sendHandoffEndEvent(
+	originalTask *Task,
+	result *HandoffResult,
+	callback EventCallback,
+) {
+	event := map[string]interface{}{
+		"original_task": originalTask.ID,
+		"success":       result.Success,
+		"new_agent":     result.NewExpert,
+		"error":         result.Error,
+	}
+	h.sendEvent(EventTypeHandoffEnd, event, callback)
+}
+
+// sendEvent marshals and sends an event via the callback.
+func (h *HandoffHandler) sendEvent(eventType string, data map[string]any, callback EventCallback) {
+	eventJSON, err := json.Marshal(data)
+	if err != nil {
+		slog.Error("handoff: failed to marshal event", "error", err)
+		return
+	}
+	callback(eventType, string(eventJSON))
+}
+
+// Ensure HandoffHandler implements error handling
+var _ error = (*HandoffError)(nil)
+
+// HandoffError represents an error that occurred during handoff.
+type HandoffError struct {
+	OriginalError error
+	TaskID        string
+	Expert        string
+}
+
+func (e *HandoffError) Error() string {
+	if e.OriginalError != nil {
+		return e.OriginalError.Error()
+	}
+	return "handoff error"
+}
+
+func (e *HandoffError) Unwrap() error {
+	return e.OriginalError
+}
+
+// NewHandoffError creates a new HandoffError.
+func NewHandoffError(taskID, expert string, err error) *HandoffError {
+	return &HandoffError{
+		OriginalError: err,
+		TaskID:        taskID,
+		Expert:        expert,
+	}
+}
+
+// IsHandoffError checks if an error is a HandoffError.
+func IsHandoffError(err error) bool {
+	var handoffErr *HandoffError
+	return errors.As(err, &handoffErr)
+}

--- a/config/parrots/memo.yaml
+++ b/config/parrots/memo.yaml
@@ -96,18 +96,17 @@ long_term_memory:
     min_similarity: 0.75           # Minimum similarity threshold (0-1)
     embedding_model: "BAAI/bge-m3" # Embedding model for vector search
 
-# Self-description for Orchestrator routing
+# Self-description for Orchestrator routing (Handoff mechanism)
+# NOTE: Experts only declare capabilities, NOT limitations.
+# Limitations are discovered at runtime and trigger Handoff.
 self_description:
   name: memo
   emoji: "📝"
   title: "笔记搜索专家"
   capabilities:
-    - "语义搜索用户记录的笔记、文档、想法"
-    - "按时间浏览笔记列表"
-    - "查找特定话题的相关内容"
-  limitations:
-    - "只能搜索已有笔记，不能创建新笔记"
-    - "不能修改或删除笔记"
+    - "搜索笔记内容"
+    - "按时间浏览笔记"
+    - "查找相关内容"
   working_style: "适用场景：用户想查找之前记录的信息、浏览历史笔记、搜索特定话题"
   personality:
     - "精准"

--- a/config/parrots/schedule.yaml
+++ b/config/parrots/schedule.yaml
@@ -104,19 +104,18 @@ long_term_memory:
     min_similarity: 0.0
     embedding_model: "BAAI/bge-m3"
 
-# Self-description for Orchestrator routing
+# Self-description for Orchestrator routing (Handoff mechanism)
+# NOTE: Experts only declare capabilities, NOT limitations.
+# Limitations are discovered at runtime and trigger Handoff.
 self_description:
   name: schedule
   emoji: "📅"
   title: "日程管理专家"
   capabilities:
-    - "创建、查询、更新日程安排"
-    - "智能处理时间冲突"
-    - "查找空闲时间段"
-    - "解析自然语言时间表达"
-  limitations:
-    - "不能处理跨时区日程"
-    - "不能发送会议邀请"
+    - "创建日程"
+    - "查询日程"
+    - "更新日程"
+    - "查找空闲时间"
   working_style: "适用场景：时间管理、会议安排、查看日程、修改已有安排、查找空闲时间"
   personality:
     - "严谨"


### PR DESCRIPTION
## Summary
实现 Expert Agent Handoff 机制，支持粘性路由场景下专家间的动态任务转交。

### 主要变更
- 新增 `CapabilityMap`：从专家配置构建能力到专家的运行时映射
- 新增 `HandoffHandler`：处理任务失败并执行动态转交
- 修改 `Executor`：集成 HandoffHandler 支持任务自动重试
- 更新专家配置：memo 和 schedule 只声明 capabilities（移除 limitations）

### Handoff 流程
当专家无法完成任务时：
1. 报告缺失能力
2. Orchestrator 查询 CapabilityMap
3. 动态转交给目标专家
4. 目标专家执行并返回结果

Resolves #198

## Test plan
- [x] 单元测试通过
- [x] 集成测试通过
- [ ] 手动测试粘性路由场景