### PR TITLE
feat(ai): 实现 ScheduleParrot 日程删除功能

### DIFF
--- a/ai/agents/tools/cache.go
+++ b/ai/agents/tools/cache.go
@@ -103,6 +103,7 @@ func (c *ToolResultCache) SetDefaultTTLs() {
 		// 写操作工具 (Write operations) - 不缓存 (TTL = 0)
 		"schedule_add":    0,
 		"schedule_update": 0,
+		"schedule_delete": 0,
 	}
 }
 

--- a/ai/agents/universal/config_loader.go
+++ b/ai/agents/universal/config_loader.go
@@ -99,7 +99,7 @@ func DefaultScheduleParrotConfig() *ParrotConfig {
 		DisplayName: "Schedule Parrot",
 		Emoji:       "📅",
 		Strategy:    StrategyDirect,
-		Tools:       []string{"schedule_add", "schedule_query", "schedule_update", "find_free_time"},
+		Tools:       []string{"schedule_add", "schedule_query", "schedule_update", "schedule_delete", "find_free_time"},
 		SystemPrompt: `You are a helpful assistant for managing schedules and calendars.
 
 You can help users:
@@ -127,7 +127,7 @@ Be concise and helpful in your responses.`,
 			Title:        "Schedule Parrot",
 			Name:         "schedule",
 			Emoji:        "📅",
-			Capabilities: []string{"schedule_add", "schedule_query", "schedule_update", "find_free_time", "Schedule Management", "日程管理"},
+			Capabilities: []string{"schedule_add", "schedule_query", "schedule_update", "schedule_delete", "find_free_time", "Schedule Management", "日程管理"},
 			CapabilityTriggers: map[string][]string{
 				"Schedule Management": {"日程", "安排", "calendar", "schedule", "会议"},
 				"日程管理":                {"日程", "安排", "calendar", "schedule", "会议"},

--- a/config/parrots/schedule.yaml
+++ b/config/parrots/schedule.yaml
@@ -18,6 +18,7 @@ tools:
   - schedule_add
   - schedule_query
   - schedule_update
+  - schedule_delete
   - find_free_time
   - report_inability
 

--- a/server/router/api/v1/ai/factory.go
+++ b/server/router/api/v1/ai/factory.go
@@ -223,6 +223,22 @@ func (f *AgentFactory) buildToolFactories() map[string]universal.ToolFactoryFunc
 			), nil
 		}
 
+		factories["schedule_delete"] = func(userID int32) (agents.ToolWithSchema, error) {
+			userIDGetter := func(ctx context.Context) int32 {
+				return userID
+			}
+			scheduleSvc := schedule.NewService(f.store)
+			tool := scheduletools.NewScheduleDeleteTool(scheduleSvc, userIDGetter)
+			return agents.ToolFromLegacy(
+				tool.Name(),
+				tool.Description(),
+				func(ctx context.Context, input string) (string, error) {
+					return tool.Run(ctx, input)
+				},
+				tool.InputType,
+			), nil
+		}
+
 		factories["find_free_time"] = func(userID int32) (agents.ToolWithSchema, error) {
 			userIDGetter := func(ctx context.Context) int32 {
 				return userID


### PR DESCRIPTION
## Summary
实现 ScheduleParrot 的日程删除功能，填补 AI 工具层的功能空白。

## Changes
- 在 `ai/agents/tools/schedule/tools.go` 中新增 `ScheduleDeleteTool`
- 在 `server/router/api/v1/ai/factory.go` 中注册工具工厂
- 在 `ai/agents/universal/config_loader.go` 中添加配置
- 在 `config/parrots/schedule.yaml` 中添加工具列表
- 在 `ai/agents/tools/cache.go` 中添加缓存配置
- 更新 `docs/testing/e2e-user-manual.md` 测试手册

## Test plan
- [ ] 通过 AI Chat 测试删除日程功能
- [ ] 验证 TC-SCHEDULE-006 测试用例

Resolves #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)