### PR TITLE
fix(memo): 修复 MemoBlockV3 展开状态多个问题

### DIFF
--- a/web/src/components/Memo/MemoListV3.tsx
+++ b/web/src/components/Memo/MemoListV3.tsx
@@ -22,7 +22,6 @@ import { DEFAULT_LIST_MEMOS_PAGE_SIZE } from "@/helpers/consts";
 import { useInfiniteMemos } from "@/hooks/useMemoQueries";
 import { cn } from "@/lib/utils";
 import { State } from "@/types/proto/api/v1/common_pb";
-import type { Memo } from "@/types/proto/api/v1/memo_service_pb";
 
 // ============================================================================
 // Types
@@ -33,7 +32,7 @@ export interface MemoListV3Props {
   orderBy?: string;
   filter?: string;
   pageSize?: number;
-  onEdit?: (memo: Memo) => void;
+  onEdit?: (memoName: string) => void;
   className?: string;
 }
 
@@ -351,8 +350,8 @@ export const MemoListV3 = memo(function MemoListV3({
 
   // Handle edit action
   const handleEdit = useCallback(
-    (memo: Memo) => {
-      onEdit?.(memo);
+    (memoName: string) => {
+      onEdit?.(memoName);
     },
     [onEdit],
   );

--- a/web/src/pages/Archived.tsx
+++ b/web/src/pages/Archived.tsx
@@ -4,8 +4,6 @@ import { MemoListV3 } from "@/components/Memo";
 import { useMemoFilters, useMemoSorting } from "@/hooks";
 import useCurrentUser from "@/hooks/useCurrentUser";
 import { State } from "@/types/proto/api/v1/common_pb";
-import type { Memo } from "@/types/proto/api/v1/memo_service_pb";
-import { getMemoEditPath } from "@/utils/memo";
 
 const Archived = () => {
   const user = useCurrentUser();
@@ -26,8 +24,9 @@ const Archived = () => {
 
   // Handle memo edit - other actions are handled by MemoBlock
   const handleEdit = useCallback(
-    (memo: Memo) => {
-      navigate(getMemoEditPath(memo));
+    (memoName: string) => {
+      const memoId = memoName.split("/").pop() || memoName;
+      navigate(`/m/${memoId}`);
     },
     [navigate],
   );

--- a/web/src/pages/Explore.tsx
+++ b/web/src/pages/Explore.tsx
@@ -5,9 +5,7 @@ import { ExploreHeroSection } from "@/components/Memo/ExploreHeroSection";
 import { useMemoFilters, useMemoSorting } from "@/hooks";
 import useCurrentUser from "@/hooks/useCurrentUser";
 import { State } from "@/types/proto/api/v1/common_pb";
-import type { Memo } from "@/types/proto/api/v1/memo_service_pb";
 import { Visibility } from "@/types/proto/api/v1/memo_service_pb";
-import { getMemoEditPath } from "@/utils/memo";
 
 const Explore = () => {
   const currentUser = useCurrentUser();
@@ -33,8 +31,9 @@ const Explore = () => {
 
   // Handle memo edit - other actions are handled by MemoBlock
   const handleEdit = useCallback(
-    (memo: Memo) => {
-      navigate(getMemoEditPath(memo));
+    (memoName: string) => {
+      const memoId = memoName.split("/").pop() || memoName;
+      navigate(`/m/${memoId}`);
     },
     [navigate],
   );

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -6,7 +6,6 @@ import { FixedEditor } from "@/components/Memo/FixedEditor";
 import { useMemoFilters, useMemoSorting } from "@/hooks";
 import useCurrentUser from "@/hooks/useCurrentUser";
 import { State } from "@/types/proto/api/v1/common_pb";
-import type { Memo } from "@/types/proto/api/v1/memo_service_pb";
 
 const Home = () => {
   const { t } = useTranslation();
@@ -28,8 +27,8 @@ const Home = () => {
 
   // Handle memo edit
   const handleEdit = useCallback(
-    (memo: Memo) => {
-      const memoId = memo.name.split("/").pop() || memo.name;
+    (memoName: string) => {
+      const memoId = memoName.split("/").pop() || memoName;
       navigate(`/m/${memoId}`);
     },
     [navigate],


### PR DESCRIPTION
## Summary

### Bug Fixes
修复 MemoBlockV3 组件在展开状态下的多个 UI 和交互问题：

1. **Body 缺少创建者信息** - 添加 `showCreator={true}`
2. **Header 时间显示 "未知"** - 使用 `timestampDate` 正确解析
3. **MemoView 背景样式未正确覆盖** - 移除 `!` 前缀
4. **折叠状态持久化不完整** - 初始化时读取 localStorage
5. **handleEdit 依赖整个 memo 对象** - 只依赖 `memo.name`
6. **isLatest prop 从未被使用** - 移除
7. **hideInteractionButtons 设置错误** - 设置为 `true`

### New Feature
**全屏阅读模式**：
- 在 Footer 工具栏添加全屏阅读按钮
- 点击进入沉浸式阅读模态框（模态框，非浏览器全屏）
- 模态框显示 Markdown 内容和作者信息
- 右上角退出按钮关闭阅读模式

Resolves #245

## Test plan

- [ ] 验证 MemoBlock 展开后显示创建者信息
- [ ] 验证 Header 时间正确显示
- [ ] 验证展开内容背景样式正确
- [ ] 验证折叠状态在刷新后正确恢复
- [ ] 验证编辑功能正常工作
- [ ] 验证展开后无重复的互动按钮
- [ ] 验证全屏阅读按钮正常工作
- [ ] 验证全屏模式下退出按钮正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)